### PR TITLE
reduce allocations and implement allocator stats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,4 @@ serial_test = "^2"
 default = ["zksync"]
 zksync = ["circuit_definitions"]
 recompute = []
+allocator_stats = []

--- a/src/context.rs
+++ b/src/context.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub struct ProverContext;
 
-pub const ZKSYNC_DEFAULT_TRACE_LOG_LENGTH: usize = 19;
+pub const ZKSYNC_DEFAULT_TRACE_LOG_LENGTH: usize = 20;
 
 impl ProverContext {
     pub fn create() -> CudaResult<Self> {

--- a/src/data_structures/arguments.rs
+++ b/src/data_structures/arguments.rs
@@ -1,4 +1,5 @@
 use boojum::cs::{implementations::proof::OracleQuery, oracle::TreeHasher, LookupParameters};
+use std::rc::Rc;
 
 use super::*;
 
@@ -303,8 +304,7 @@ impl<'a> LeafSourceQuery for ArgumentPolynomials<'a, CosetEvaluations> {
 
 pub struct ArgumentCache<'a> {
     monomials: GenericArgumentStorage<'a, MonomialBasis>,
-    cosets: Vec<Option<GenericArgumentStorage<'a, CosetEvaluations>>>,
-    tmp_coset: GenericArgumentStorage<'a, CosetEvaluations>,
+    cosets: Vec<Option<Rc<GenericArgumentStorage<'a, CosetEvaluations>>>>,
     fri_lde_degree: usize,
     used_lde_degree: usize,
 }
@@ -318,18 +318,11 @@ impl<'a> ArgumentCache<'a> {
         assert!(fri_lde_degree.is_power_of_two());
         assert!(used_lde_degree.is_power_of_two());
 
-        let mut cosets = Vec::with_capacity(fri_lde_degree);
-        for _ in 0..fri_lde_degree {
-            cosets.push(None);
-        }
-
-        let tmp_coset =
-            GenericArgumentStorage::allocate(monomials.layout.clone(), monomials.domain_size())?;
+        let cosets = vec![None; fri_lde_degree];
 
         Ok(Self {
             monomials,
             cosets,
-            tmp_coset,
             fri_lde_degree,
             used_lde_degree,
         })
@@ -370,13 +363,17 @@ impl<'a> ArgumentCache<'a> {
     pub fn get_or_compute_coset_evals(
         &mut self,
         coset_idx: usize,
-    ) -> CudaResult<&GenericArgumentStorage<CosetEvaluations>> {
+    ) -> CudaResult<Rc<GenericArgumentStorage<CosetEvaluations>>> {
         assert!(coset_idx < self.used_lde_degree);
 
         if REMEMBER_COSETS == false || coset_idx >= self.fri_lde_degree {
+            let mut tmp_coset = GenericArgumentStorage::allocate(
+                self.monomials.layout.clone(),
+                self.monomials.domain_size(),
+            )?;
             self.monomials
-                .into_coset_eval(coset_idx, self.used_lde_degree, &mut self.tmp_coset)?;
-            return Ok(&self.tmp_coset);
+                .into_coset_eval(coset_idx, self.used_lde_degree, &mut tmp_coset)?;
+            return Ok(Rc::new(tmp_coset));
         }
 
         if self.cosets[coset_idx].is_none() {
@@ -389,10 +386,10 @@ impl<'a> ArgumentCache<'a> {
                 self.used_lde_degree,
                 &mut current_storage,
             )?;
-            self.cosets[coset_idx] = Some(current_storage);
+            self.cosets[coset_idx] = Some(Rc::new(current_storage));
         }
 
-        return Ok(self.cosets[coset_idx].as_ref().unwrap());
+        return Ok(self.cosets[coset_idx].as_ref().unwrap().clone());
     }
 
     #[allow(dead_code)]
@@ -453,8 +450,7 @@ impl<'a> ArgumentCache<'a> {
 
 pub struct QuotientCache<'a> {
     monomials: GenericComplexPolynomialStorage<'a, MonomialBasis>,
-    cosets: Vec<Option<GenericComplexPolynomialStorage<'a, CosetEvaluations>>>,
-    tmp_coset: GenericComplexPolynomialStorage<'a, CosetEvaluations>,
+    cosets: Vec<Option<Rc<GenericComplexPolynomialStorage<'a, CosetEvaluations>>>>,
     fri_lde_degree: usize,
     used_lde_degree: usize,
 }
@@ -468,20 +464,11 @@ impl<'a> QuotientCache<'a> {
         assert!(fri_lde_degree.is_power_of_two());
         assert!(used_lde_degree.is_power_of_two());
 
-        let mut cosets = Vec::with_capacity(fri_lde_degree);
-        for _ in 0..fri_lde_degree {
-            cosets.push(None);
-        }
-
-        let tmp_coset = GenericComplexPolynomialStorage::allocate(
-            monomials.num_polys(),
-            monomials.domain_size(),
-        )?;
+        let cosets = vec![None; fri_lde_degree];
 
         Ok(Self {
             monomials,
             cosets,
-            tmp_coset,
             fri_lde_degree,
             used_lde_degree,
         })
@@ -523,13 +510,17 @@ impl<'a> QuotientCache<'a> {
     pub fn get_or_compute_coset_evals(
         &mut self,
         coset_idx: usize,
-    ) -> CudaResult<&GenericComplexPolynomialStorage<'a, CosetEvaluations>> {
+    ) -> CudaResult<Rc<GenericComplexPolynomialStorage<'a, CosetEvaluations>>> {
         assert!(coset_idx < self.used_lde_degree);
 
         if REMEMBER_COSETS == false || coset_idx >= self.fri_lde_degree {
+            let mut tmp_coset = GenericComplexPolynomialStorage::allocate(
+                self.monomials.num_polys(),
+                self.monomials.domain_size(),
+            )?;
             self.monomials
-                .into_coset_eval(coset_idx, self.used_lde_degree, &mut self.tmp_coset)?;
-            return Ok(&self.tmp_coset);
+                .into_coset_eval(coset_idx, self.used_lde_degree, &mut tmp_coset)?;
+            return Ok(Rc::new(tmp_coset));
         }
 
         if self.cosets[coset_idx].is_none() {
@@ -542,10 +533,10 @@ impl<'a> QuotientCache<'a> {
                 self.used_lde_degree,
                 &mut current_storage,
             )?;
-            self.cosets[coset_idx] = Some(current_storage);
+            self.cosets[coset_idx] = Some(Rc::new(current_storage));
         }
 
-        return Ok(self.cosets[coset_idx].as_ref().unwrap());
+        return Ok(self.cosets[coset_idx].as_ref().unwrap().clone());
     }
 
     #[allow(dead_code)]
@@ -559,7 +550,7 @@ impl<'a> QuotientCache<'a> {
     ) -> CudaResult<OracleQuery<F, H>> {
         let leaf_sources = self.get_or_compute_coset_evals(coset_idx)?;
         tree_holder.get_quotient_subtrees().query(
-            leaf_sources,
+            leaf_sources.as_ref(),
             coset_idx,
             fri_lde_degree,
             row_idx,

--- a/src/data_structures/arguments.rs
+++ b/src/data_structures/arguments.rs
@@ -1,4 +1,5 @@
 use boojum::cs::{implementations::proof::OracleQuery, oracle::TreeHasher, LookupParameters};
+use std::ops::Deref;
 use std::rc::Rc;
 
 use super::*;
@@ -427,7 +428,7 @@ impl<'a> ArgumentCache<'a> {
         batch_query::<H, A>(
             indexes,
             num_queries,
-            leaf_sources,
+            leaf_sources.deref(),
             num_polys,
             oracle_data,
             oracle_data.cap_size,
@@ -574,7 +575,7 @@ impl<'a> QuotientCache<'a> {
         batch_query::<H, A>(
             indexes,
             num_queries,
-            leaf_sources,
+            leaf_sources.deref(),
             num_polys,
             oracle_data,
             oracle_data.cap_size,

--- a/src/data_structures/setup.rs
+++ b/src/data_structures/setup.rs
@@ -2,6 +2,7 @@ use boojum::cs::{
     implementations::{polynomial_storage::SetupBaseStorage, proof::OracleQuery},
     oracle::TreeHasher,
 };
+use std::rc::Rc;
 
 use crate::cs::{materialize_permutation_cols_from_transformed_hints_into, GpuSetup};
 
@@ -365,8 +366,7 @@ impl GenericSetupStorage<CosetEvaluations> {
 
 pub struct SetupCache {
     monomials: GenericSetupStorage<MonomialBasis>,
-    cosets: Vec<Option<GenericSetupStorage<CosetEvaluations>>>,
-    tmp_coset: GenericSetupStorage<CosetEvaluations>,
+    cosets: Vec<Option<Rc<GenericSetupStorage<CosetEvaluations>>>>,
     fri_lde_degree: usize,
     used_lde_degree: usize,
 }
@@ -379,19 +379,12 @@ impl SetupCache {
     ) -> CudaResult<Self> {
         assert!(fri_lde_degree.is_power_of_two());
         assert!(used_lde_degree.is_power_of_two());
-        let domain_size = monomial_setup.domain_size();
 
-        let mut cosets = Vec::with_capacity(fri_lde_degree);
-        for _ in 0..fri_lde_degree {
-            cosets.push(None);
-        }
-
-        let tmp_coset = GenericSetupStorage::allocate(monomial_setup.layout.clone(), domain_size)?;
+        let cosets = vec![None; fri_lde_degree];
 
         let this = Self {
             monomials: monomial_setup,
             cosets,
-            tmp_coset,
             fri_lde_degree,
             used_lde_degree,
         };
@@ -429,13 +422,17 @@ impl SetupCache {
     pub fn get_or_compute_coset_evals(
         &mut self,
         coset_idx: usize,
-    ) -> CudaResult<&GenericSetupStorage<CosetEvaluations>> {
+    ) -> CudaResult<Rc<GenericSetupStorage<CosetEvaluations>>> {
         assert!(coset_idx < self.used_lde_degree);
 
         if REMEMBER_COSETS == false || coset_idx >= self.fri_lde_degree {
+            let mut tmp_coset = GenericSetupStorage::allocate(
+                self.monomials.layout.clone(),
+                self.monomials.domain_size(),
+            )?;
             self.monomials
-                .into_coset_eval(coset_idx, self.used_lde_degree, &mut self.tmp_coset)?;
-            return Ok(&self.tmp_coset);
+                .into_coset_eval(coset_idx, self.used_lde_degree, &mut tmp_coset)?;
+            return Ok(Rc::new(tmp_coset));
         }
 
         if self.cosets[coset_idx].is_none() {
@@ -449,10 +446,10 @@ impl SetupCache {
                 self.used_lde_degree,
                 &mut current_storage,
             )?;
-            self.cosets[coset_idx] = Some(current_storage);
+            self.cosets[coset_idx] = Some(Rc::new(current_storage));
         }
 
-        return Ok(self.cosets[coset_idx].as_ref().unwrap());
+        return Ok(self.cosets[coset_idx].as_ref().unwrap().clone());
     }
 
     #[allow(dead_code)]

--- a/src/data_structures/setup.rs
+++ b/src/data_structures/setup.rs
@@ -2,6 +2,7 @@ use boojum::cs::{
     implementations::{polynomial_storage::SetupBaseStorage, proof::OracleQuery},
     oracle::TreeHasher,
 };
+use std::ops::Deref;
 use std::rc::Rc;
 
 use crate::cs::{materialize_permutation_cols_from_transformed_hints_into, GpuSetup};
@@ -486,7 +487,7 @@ impl SetupCache {
         batch_query::<H, A>(
             indexes,
             num_queries,
-            leaf_sources,
+            leaf_sources.deref(),
             leaf_sources.num_polys(),
             oracle_data,
             oracle_data.cap_size,

--- a/src/data_structures/trace.rs
+++ b/src/data_structures/trace.rs
@@ -12,6 +12,7 @@ use boojum::{
     field::U64Representable,
     worker::Worker,
 };
+use std::ops::Deref;
 use std::rc::Rc;
 
 use crate::{
@@ -809,7 +810,7 @@ impl TraceCache {
         batch_query::<H, A>(
             indexes,
             num_queries,
-            leaf_sources,
+            leaf_sources.deref(),
             leaf_sources.num_polys(),
             oracle_data,
             oracle_data.cap_size,

--- a/src/data_structures/trace.rs
+++ b/src/data_structures/trace.rs
@@ -12,6 +12,7 @@ use boojum::{
     field::U64Representable,
     worker::Worker,
 };
+use std::rc::Rc;
 
 use crate::{
     cs::{variable_assignment, GpuSetup},
@@ -695,8 +696,7 @@ impl AsSingleSlice for &GenericTraceStorage<CosetEvaluations> {
 // - or keeps coset evals
 pub struct TraceCache {
     monomials: GenericTraceStorage<MonomialBasis>,
-    cosets: Vec<Option<GenericTraceStorage<CosetEvaluations>>>,
-    tmp_coset: GenericTraceStorage<CosetEvaluations>,
+    cosets: Vec<Option<Rc<GenericTraceStorage<CosetEvaluations>>>>,
     fri_lde_degree: usize,
     used_lde_degree: usize,
 }
@@ -710,14 +710,9 @@ impl TraceCache {
         assert!(fri_lde_degree.is_power_of_two());
         assert!(used_lde_degree.is_power_of_two());
         let cosets = vec![None; fri_lde_degree];
-        let tmp_coset = GenericTraceStorage::allocate(
-            monomial_trace.domain_size(),
-            monomial_trace.layout.clone(),
-        )?;
         Ok(Self {
             monomials: monomial_trace,
-            cosets: cosets,
-            tmp_coset,
+            cosets,
             fri_lde_degree,
             used_lde_degree,
         })
@@ -751,13 +746,17 @@ impl TraceCache {
     pub fn get_or_compute_coset_evals(
         &mut self,
         coset_idx: usize,
-    ) -> CudaResult<&GenericTraceStorage<CosetEvaluations>> {
+    ) -> CudaResult<Rc<GenericTraceStorage<CosetEvaluations>>> {
         assert!(coset_idx < self.used_lde_degree);
 
         if REMEMBER_COSETS == false || coset_idx >= self.fri_lde_degree {
+            let mut tmp_coset = GenericTraceStorage::allocate(
+                self.monomials.domain_size(),
+                self.monomials.layout.clone(),
+            )?;
             self.monomials
-                .into_coset_eval(coset_idx, self.used_lde_degree, &mut self.tmp_coset)?;
-            return Ok(&self.tmp_coset);
+                .into_coset_eval(coset_idx, self.used_lde_degree, &mut tmp_coset)?;
+            return Ok(Rc::new(tmp_coset));
         }
 
         if self.cosets[coset_idx].is_none() {
@@ -770,10 +769,10 @@ impl TraceCache {
                 self.used_lde_degree,
                 &mut current_storage,
             )?;
-            self.cosets[coset_idx] = Some(current_storage);
+            self.cosets[coset_idx] = Some(Rc::new(current_storage));
         }
 
-        return Ok(self.cosets[coset_idx].as_ref().unwrap());
+        return Ok(self.cosets[coset_idx].as_ref().unwrap().clone());
     }
 
     #[allow(dead_code)]

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -847,15 +847,12 @@ fn gpu_prove_from_trace<
     let z = h_z.clone().into();
     let z_omega = h_z_omega.clone().into();
     for coset_idx in 0..fri_lde_degree {
-        let trace_polys = trace_holder
-            .get_or_compute_coset_evals(coset_idx)?
-            .as_polynomials();
-        let setup_polys = setup_holder
-            .get_or_compute_coset_evals(coset_idx)?
-            .as_polynomials();
-        let argument_polys = argument_holder
-            .get_or_compute_coset_evals(coset_idx)?
-            .as_polynomials();
+        let trace_values = trace_holder.get_or_compute_coset_evals(coset_idx)?;
+        let trace_polys = trace_values.as_polynomials();
+        let setup_values = setup_holder.get_or_compute_coset_evals(coset_idx)?;
+        let setup_polys = setup_values.as_polynomials();
+        let argument_values = argument_holder.get_or_compute_coset_evals(coset_idx)?;
+        let argument_polys = argument_values.as_polynomials();
         let quotient_polys = quotient_holder.get_or_compute_coset_evals(coset_idx)?;
 
         let coset_omegas = compute_omega_values_for_coset(coset_idx, domain_size, used_lde_degree)?;

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -1090,6 +1090,14 @@ fn gpu_prove_from_trace<
 
     synchronize_streams()?;
     println!("FRI Queries are done {:?}", time.elapsed());
+    #[cfg(feature = "allocator_stats")]
+    unsafe {
+        dbg!(_DEVICE_ALLOCATOR.as_ref().unwrap().get_allocation_stats());
+        dbg!(_SMALL_DEVICE_ALLOCATOR
+            .as_ref()
+            .unwrap()
+            .get_allocation_stats());
+    }
 
     gpu_proof.public_inputs = public_inputs;
     gpu_proof.witness_oracle_cap = trace_tree_cap;

--- a/src/static_allocator/device.rs
+++ b/src/static_allocator/device.rs
@@ -19,6 +19,8 @@ pub struct StaticDeviceAllocator {
     maximum_tail_index: Arc<AtomicUsize>,
 }
 
+#[derive(Derivative)]
+#[derivative(Clone, Debug)]
 pub struct AllocationStats {
     pub current_block_count: usize,
     pub current_tail_index: usize,


### PR DESCRIPTION
# What ❔

This PR
- extends virtual allocators with statistics tracking and computing
- improves the implementation of the temporary allocations resulting in reduced GPU memory usage
- reduces the size of the allocation for the "Small" allocator because there is no need for an order of magnitude larger allocation again resulting in reduced GPU memory usage

## Why ❔

Virtual allocator statistics are needed to determine the memory requirements and to help with determining what the memory usage is in various places during the proof generation.
Minimizing memory usage allows to run the prover on GPUs with less available memory.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
