### PR TITLE
Only compute denom_at_zero if lookup is used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# boojum = { path = "../boojum" }
-boojum-cuda = { path = "../era-boojum-cuda/boojum-cuda" }
-cudart = { path = "../era-boojum-cuda/cudart", package = "cudart" }
-# circuit_definitions = { path = "../zkevm_test_harness/circuit_definitions", package = "circuit_definitions", optional = true }
+# boojum = { path = "../era-boojum" }
+# boojum-cuda = { path = "../era-boojum-cuda/boojum-cuda" }
+# cudart = { path = "../era-boojum-cuda/cudart", package = "cudart" }
+# circuit_definitions = { path = "../era-zkevm_test_harness/circuit_definitions", package = "circuit_definitions", optional = true }
 
 boojum = {git = "https://github.com/matter-labs/era-boojum", branch = "main"}
-# boojum-cuda = {git = "https://github.com/matter-labs/era-boojum-cuda", branch = "main", package = "boojum-cuda"}
-# cudart= {git = "https://github.com/matter-labs/era-boojum-cuda", branch = "main", package = "cudart"}
+boojum-cuda = {git = "https://github.com/matter-labs/era-boojum-cuda", branch = "main", package = "boojum-cuda"}
+cudart= {git = "https://github.com/matter-labs/era-boojum-cuda", branch = "main", package = "cudart"}
 circuit_definitions = {git = "https://github.com/matter-labs/era-zkevm_test_harness", branch = "v1.4.0", package = "circuit_definitions", optional = true}
 
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,13 +7,13 @@ edition = "2021"
 
 [dependencies]
 # boojum = { path = "../boojum" }
-# boojum-cuda = { path = "../boojum-cuda/boojum-cuda" }
-# cudart = { path = "../boojum-cuda/cudart", package = "cudart" }
+boojum-cuda = { path = "../era-boojum-cuda/boojum-cuda" }
+cudart = { path = "../era-boojum-cuda/cudart", package = "cudart" }
 # circuit_definitions = { path = "../zkevm_test_harness/circuit_definitions", package = "circuit_definitions", optional = true }
 
 boojum = {git = "https://github.com/matter-labs/era-boojum", branch = "main"}
-boojum-cuda = {git = "https://github.com/matter-labs/era-boojum-cuda", branch = "main", package = "boojum-cuda"}
-cudart= {git = "https://github.com/matter-labs/era-boojum-cuda", branch = "main", package = "cudart"}
+# boojum-cuda = {git = "https://github.com/matter-labs/era-boojum-cuda", branch = "main", package = "boojum-cuda"}
+# cudart= {git = "https://github.com/matter-labs/era-boojum-cuda", branch = "main", package = "cudart"}
 circuit_definitions = {git = "https://github.com/matter-labs/era-zkevm_test_harness", branch = "v1.4.0", package = "circuit_definitions", optional = true}
 
 rand = "0.8"

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -1077,19 +1077,24 @@ fn compute_deep_quotiening_over_coset(
 
     let denom_at_z = compute_denom_at_ext_point(&roots, &z)?;
     let denom_at_z_omega = compute_denom_at_ext_point(&roots, &z_omega)?;
-    let denom_at_zero = compute_denom_at_base_point(&roots, &DF::zero()?)?;
 
-    let (maybe_multiplicity_cols, maybe_lookup_a_polys, maybe_lookup_b_polys, maybe_table_cols) =
-        if argument_polys.lookup_a_polys.len() > 0 {
-            (
-                Some(&trace_polys.multiplicity_cols),
-                Some(argument_polys.lookup_a_polys),
-                Some(argument_polys.lookup_b_polys),
-                Some(&setup_polys.table_cols),
-            )
-        } else {
-            (None, None, None, None)
-        };
+    let (
+        maybe_multiplicity_cols,
+        maybe_lookup_a_polys,
+        maybe_lookup_b_polys,
+        maybe_table_cols,
+        maybe_denom_at_zero,
+    ) = if argument_polys.lookup_a_polys.len() > 0 {
+        (
+            Some(&trace_polys.multiplicity_cols),
+            Some(argument_polys.lookup_a_polys),
+            Some(argument_polys.lookup_b_polys),
+            Some(&setup_polys.table_cols),
+            Some(compute_denom_at_base_point(&roots, &DF::zero()?)?),
+        )
+    } else {
+        (None, None, None, None, None)
+    };
 
     let maybe_witness_cols = if trace_polys.witness_cols.len() > 0 {
         Some(&trace_polys.witness_cols)
@@ -1120,7 +1125,7 @@ fn compute_deep_quotiening_over_coset(
         &challenges[..challenges.len() - num_public_inputs],
         &denom_at_z,
         &denom_at_z_omega,
-        &denom_at_zero,
+        &maybe_denom_at_zero,
         &mut quotient,
     )?;
 


### PR DESCRIPTION
# What ❔

This PR implements a small optimization I missed in the original lookup PR: it makes sure we only compute `denom_at_zero` if necessary, ie, if the circuit needs lookup.
Companion to https://github.com/matter-labs/era-boojum-cuda/pull/11.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
