### PR TITLE
Add an assert that there is no placeholder in a public input location

### DIFF
--- a/src/prover.rs
+++ b/src/prover.rs
@@ -98,6 +98,11 @@ pub fn gpu_prove_from_external_witness_data<
         .cloned()
     {
         let variable_idx = setup.variables_hint[col][row].clone() as usize;
+        assert_eq!(
+            variable_idx & (1 << 31),
+            0,
+            "placeholder found in a public input location"
+        );
         let value = external_witness_data.all_values[variable_idx];
         public_inputs_with_locations.push((col, row, value));
     }


### PR DESCRIPTION
# What ❔

This PR adds an assert that there is no placeholder in a public input location.

## Why ❔

When there is a mismatch between the setup and the witness data a placeholder index can appear in a public input location and generate a generic index out of bounds error. This adds an explicit check with a descriptive error message.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted via `cargo fmt` and linted via `cargo check`.
