### PR TITLE
switch source of the cudart crate to era-cuda repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,14 +7,14 @@ edition = "2021"
 
 [dependencies]
 # boojum = { path = "../era-boojum", package = "boojum" }
-# boojum-cuda = { path = "../era-boojum-cuda/boojum-cuda", package = "boojum-cuda" }
-# cudart = { path = "../era-boojum-cuda/cudart", package = "cudart" }
+# boojum-cuda = { path = "../era-boojum-cuda" }
+# cudart = { path = "../era-cuda/cudart", package = "cudart" }
 # circuit_definitions = { path = "../era-zkevm_test_harness/circuit_definitions", package = "circuit_definitions", optional = true }
 
-boojum = {git = "https://github.com/matter-labs/era-boojum", branch = "main"}
-boojum-cuda = {git = "https://github.com/matter-labs/era-boojum-cuda", branch = "main", package = "boojum-cuda"}
-cudart= {git = "https://github.com/matter-labs/era-boojum-cuda", branch = "main", package = "cudart"}
-circuit_definitions = {git = "https://github.com/matter-labs/era-zkevm_test_harness", branch = "v1.4.0", package = "circuit_definitions", optional = true}
+boojum = { git = "https://github.com/matter-labs/era-boojum", branch = "main" }
+boojum-cuda = { git = "https://github.com/matter-labs/era-boojum-cuda", branch = "main" }
+cudart = { git = "https://github.com/matter-labs/era-cuda", branch = "main", package = "cudart" }
+circuit_definitions = { git = "https://github.com/matter-labs/era-zkevm_test_harness", branch = "v1.4.0", package = "circuit_definitions", optional = true }
 
 rand = "0.8"
 smallvec = { version = "*", features = [


### PR DESCRIPTION
# What ❔

This PR switches the source of the cudart crate to the era-cuda repository. 
Requires https://github.com/matter-labs/era-boojum-cuda/pull/19 to be merged.

## Why ❔

General CUDA crates were separated from boojum-cuda repo to allow reuse outside of boojum.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
