### PR TITLE
Implement differing memory limits for variants with and without re-computation

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -25,7 +25,7 @@ impl ProverContext {
         let device_alloc = StaticDeviceAllocator::init_all(block_size)?;
 
         let small_host_alloc = SmallStaticHostAllocator::init()?;
-        let host_alloc = StaticHostAllocator::init(block_size, 1 << 8)?;
+        let host_alloc = StaticHostAllocator::init(1 << 8, block_size)?;
 
         unsafe {
             _CUDA_CONTEXT = Some(cuda_ctx);
@@ -42,7 +42,7 @@ impl ProverContext {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn create_14gb_dev(block_size: usize) -> CudaResult<Self> {
+    pub(crate) fn create_limited_dev(block_size: usize) -> CudaResult<Self> {
         unsafe {
             assert!(_CUDA_CONTEXT.is_none());
             assert!(_DEVICE_ALLOCATOR.is_none());
@@ -58,10 +58,9 @@ impl ProverContext {
 
         // grab small slice then consume everything
         let small_device_alloc = SmallStaticDeviceAllocator::init()?;
-        let device_alloc = StaticDeviceAllocator::init_14gb(block_size)?;
-        println!("allocated 14gb on device");
+        let device_alloc = StaticDeviceAllocator::init_limited(block_size)?;
         let small_host_alloc = SmallStaticHostAllocator::init()?;
-        let host_alloc = StaticHostAllocator::init(block_size, 1 << 8)?;
+        let host_alloc = StaticHostAllocator::init(1 << 8, block_size)?;
 
         unsafe {
             _CUDA_CONTEXT = Some(cuda_ctx);
@@ -77,7 +76,7 @@ impl ProverContext {
         Ok(Self {})
     }
 
-    pub fn create_14gb() -> CudaResult<Self> {
+    pub fn create_limited() -> CudaResult<Self> {
         unsafe {
             assert!(_CUDA_CONTEXT.is_none());
             assert!(_DEVICE_ALLOCATOR.is_none());
@@ -94,10 +93,9 @@ impl ProverContext {
 
         // grab small slice then consume everything
         let small_device_alloc = SmallStaticDeviceAllocator::init()?;
-        let device_alloc = StaticDeviceAllocator::init_14gb(block_size)?;
-        println!("allocated 14gb on device");
+        let device_alloc = StaticDeviceAllocator::init_limited(block_size)?;
         let small_host_alloc = SmallStaticHostAllocator::init()?;
-        let host_alloc = StaticHostAllocator::init(block_size, 1 << 8)?;
+        let host_alloc = StaticHostAllocator::init(1 << 8, block_size)?;
 
         unsafe {
             _CUDA_CONTEXT = Some(cuda_ctx);
@@ -124,7 +122,7 @@ impl ProverContext {
         let device_alloc = StaticDeviceAllocator::init_all(block_size)?;
 
         let small_host_alloc = SmallStaticHostAllocator::init()?;
-        let host_alloc = StaticHostAllocator::init(block_size, 1 << 8)?;
+        let host_alloc = StaticHostAllocator::init(1 << 8, block_size)?;
 
         unsafe {
             _CUDA_CONTEXT = Some(cuda_ctx);

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -410,7 +410,7 @@ mod tests {
     #[test]
     #[ignore]
     fn test_batch_query_for_leaf_sources() -> CudaResult<()> {
-        let _ctx = ProverContext::create_14gb()?;
+        let _ctx = ProverContext::create_limited()?;
         let domain_size = 1 << 16;
         let lde_degree = 2;
         let num_cols = 2;
@@ -536,7 +536,7 @@ mod tests {
     #[test]
     #[ignore]
     fn test_batch_query_for_fri_layers() -> CudaResult<()> {
-        let _ctx = ProverContext::create_14gb()?;
+        let _ctx = ProverContext::create_limited()?;
         let domain_size = 1 << 16;
         let lde_degree = 2;
         let num_cols = 2;
@@ -692,7 +692,7 @@ mod tests {
     #[test]
     #[ignore]
     fn test_batch_query_for_merkle_paths() -> CudaResult<()> {
-        let _ctx = ProverContext::create_14gb()?;
+        let _ctx = ProverContext::create_limited()?;
         let domain_size = 1 << 4;
         let lde_degree = 2;
         let num_cols = 2;

--- a/src/test.rs
+++ b/src/test.rs
@@ -1035,7 +1035,7 @@ mod zksync {
     #[ignore]
     fn compare_proofs_for_single_zksync_circuit_in_single_shot() {
         let circuit = get_circuit_from_env();
-        let _ctx = ProverContext::create_14gb().expect("gpu prover context");
+        let _ctx = ProverContext::create_limited().expect("gpu prover context");
 
         println!(
             "{} {}",


### PR DESCRIPTION
# What ❔

This PR implements  differing memory limits for variants with and without re-computation, enabling to run on GPUs with 11 or 14 GB of free VRAM respectively.
It also implements refactorings in the memory allocation parts of the code.

## Why ❔

It is desirable to know the exact memory requirements for the prover and also having the option to run on GPUs with just 12 GB or RAM.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted via `cargo fmt` and `cargo check`.
