### PR TITLE
[WIP] Allow external caching of on-device setup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ derivative = "*"
 bincode = "*"
 serde = { version = "1.0", features = ["derive"] }
 
+nvtx = "1.2"
+
 
 [dev-dependencies]
 serial_test = "^2"

--- a/src/cs/setup.rs
+++ b/src/cs/setup.rs
@@ -14,7 +14,7 @@ use boojum::{
 use boojum_cuda::ops_complex::pack_variable_indexes;
 use cudart::slice::{CudaSlice, DeviceSlice};
 
-use nvtx::{range_push, range_pop};
+use nvtx::{range_pop, range_push};
 
 use super::*;
 pub(crate) const PACKED_PLACEHOLDER_BITMASK: u32 = 1 << 31;

--- a/src/data_structures/setup.rs
+++ b/src/data_structures/setup.rs
@@ -1,6 +1,9 @@
 use boojum::config::ProvingCSConfig;
 use boojum::cs::{
-    implementations::{polynomial_storage::SetupBaseStorage, prover::ProofConfig, reference_cs::CSReferenceAssembly},
+    implementations::{
+        polynomial_storage::SetupBaseStorage, prover::ProofConfig,
+        reference_cs::CSReferenceAssembly,
+    },
     oracle::TreeHasher,
 };
 use std::ops::Deref;
@@ -11,7 +14,7 @@ use crate::prover::compute_quotient_degree;
 
 use super::*;
 
-use nvtx::{range_push, range_pop};
+use nvtx::{range_pop, range_push};
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SetupLayout {
@@ -435,7 +438,10 @@ impl SetupCache {
         &mut self,
         cap_size: usize,
     ) -> CudaResult<(&Vec<SubTree>, &Vec<[F; 4]>)> {
-        assert_eq!(self.fri_oracles_subtrees.is_none(), self.fri_oracles_caps.is_none());
+        assert_eq!(
+            self.fri_oracles_subtrees.is_none(),
+            self.fri_oracles_caps.is_none()
+        );
         if self.fri_oracles_subtrees.is_none() {
             let fri_lde_degree = self.fri_lde_degree;
             let coset_cap_size = coset_cap_size(cap_size, self.fri_lde_degree);
@@ -452,7 +458,8 @@ impl SetupCache {
                 setup_subtrees.push(subtree);
             }
 
-            self.fri_oracles_caps = Some(setup_subtree_caps.compute_cap::<H>(&mut setup_subtrees, cap_size)?);
+            self.fri_oracles_caps =
+                Some(setup_subtree_caps.compute_cap::<H>(&mut setup_subtrees, cap_size)?);
             self.fri_oracles_subtrees = Some(setup_subtrees);
         }
 

--- a/src/data_structures/trace.rs
+++ b/src/data_structures/trace.rs
@@ -182,6 +182,7 @@ pub fn construct_trace_storage_from_remote_witness_data<A: GoodAllocator>(
     fri_lde_degree: usize,
     domain_size: usize,
     setup: &GpuSetup<A>,
+    setup_cache: &mut SetupCache,
     witness_data: &WitnessVec<F>,
     lookup_parameters: &LookupParameters,
     worker: &Worker,
@@ -239,16 +240,26 @@ pub fn construct_trace_storage_from_remote_witness_data<A: GoodAllocator>(
     let (variables_monomial_storage, remaining_monomial_storage) =
         remaining_monomial_storage.split_at_mut(num_variable_cols * domain_size);
 
-    for ((variables, d_variables_raw), d_variables_monomial) in variables_hint
+    if setup_cache.variables_hint.is_none() {
+        let transferred = CudaEvent::create_with_flags(CudaEventCreateFlags::DISABLE_TIMING)?;
+        let mut variables_hint_cache = Vec::with_capacity(variables_hint.len());
+        for variables in variables_hint {
+            let mut d_variable_indexes = dvec!(variables.len());
+            mem::h2d_on_stream(variables, &mut d_variable_indexes, &inner_h2d_stream)?;
+            variables_hint_cache.push(d_variable_indexes);
+        }
+        transferred.record(&inner_h2d_stream)?;
+        get_stream().wait_event(&transferred, CudaStreamWaitEventFlags::DEFAULT)?;
+        setup_cache.variables_hint = Some(variables_hint_cache);
+    }
+
+    let variables_hint_cached = setup_cache.variables_hint.as_ref().unwrap();
+
+    for ((d_variable_indexes, d_variables_raw), d_variables_monomial) in variables_hint_cached
         .iter()
         .zip(variables_raw_storage.chunks_mut(domain_size))
         .zip(variables_monomial_storage.chunks_mut(domain_size))
     {
-        let transferred = CudaEvent::create_with_flags(CudaEventCreateFlags::DISABLE_TIMING)?;
-        let mut d_variable_indexes = dvec!(variables.len());
-        mem::h2d_on_stream(variables, &mut d_variable_indexes, &inner_h2d_stream)?;
-        transferred.record(&inner_h2d_stream)?;
-        get_stream().wait_event(&transferred, CudaStreamWaitEventFlags::DEFAULT)?;
         variable_assignment(&d_variable_indexes, &d_variable_values, d_variables_raw)?;
         let (_, padding) = d_variables_raw.split_at_mut(d_variable_indexes.len());
         if !padding.is_empty() {
@@ -266,16 +277,26 @@ pub fn construct_trace_storage_from_remote_witness_data<A: GoodAllocator>(
     // hints may not be proper rectangular, so look for at least one non-empty col
     let has_witnesses = witnesses_hint.iter().any(|v| !v.is_empty());
     if has_witnesses {
-        for ((witnesses, d_witnesses_raw), d_witnesses_monomial) in witnesses_hint
+        if setup_cache.witnesses_hint.is_none() {
+            let transferred = CudaEvent::create_with_flags(CudaEventCreateFlags::DISABLE_TIMING)?;
+            let mut witnesses_hint_cache = Vec::with_capacity(witnesses_hint.len());
+            for witnesses in witnesses_hint {
+                let mut d_witness_indexes = dvec!(witnesses.len());
+                mem::h2d_on_stream(witnesses, &mut d_witness_indexes, &inner_h2d_stream)?;
+                witnesses_hint_cache.push(d_witness_indexes);
+            }
+            transferred.record(&inner_h2d_stream)?;
+            get_stream().wait_event(&transferred, CudaStreamWaitEventFlags::DEFAULT)?;
+            setup_cache.witnesses_hint = Some(witnesses_hint_cache);
+        }
+
+        let witnesses_hint_cached = setup_cache.witnesses_hint.as_ref().unwrap();
+
+        for ((d_witness_indexes, d_witnesses_raw), d_witnesses_monomial) in witnesses_hint_cached
             .iter()
             .zip(witnesses_raw_storage.chunks_mut(domain_size))
             .zip(witnesses_monomial_storage.chunks_mut(domain_size))
         {
-            let transferred = CudaEvent::create_with_flags(CudaEventCreateFlags::DISABLE_TIMING)?;
-            let mut d_witness_indexes = dvec!(witnesses.len());
-            mem::h2d_on_stream(witnesses, &mut d_witness_indexes, &inner_h2d_stream)?;
-            transferred.record(&inner_h2d_stream)?;
-            get_stream().wait_event(&transferred, CudaStreamWaitEventFlags::DEFAULT)?;
             range_push!("variable_assignment");
             variable_assignment(&d_witness_indexes, &d_variable_values, d_witnesses_raw)?;
             range_pop!();

--- a/src/data_structures/trace.rs
+++ b/src/data_structures/trace.rs
@@ -22,7 +22,7 @@ use crate::{
 
 use super::*;
 
-use nvtx::{range_push, range_pop};
+use nvtx::{range_pop, range_push};
 
 #[derive(Clone, Debug)]
 pub struct TraceLayout {

--- a/src/data_structures/tree.rs
+++ b/src/data_structures/tree.rs
@@ -9,7 +9,7 @@ enum OracleType {
     Trace,
     Argument,
     Quotient,
-    Setup,
+    // Setup,
 }
 
 impl OracleType {
@@ -18,7 +18,7 @@ impl OracleType {
             OracleType::Trace => "Trace",
             OracleType::Argument => "Argument",
             OracleType::Quotient => "Quotient",
-            OracleType::Setup => "Setup",
+            // OracleType::Setup => "Setup",
         }
     }
 }
@@ -27,10 +27,10 @@ impl OracleType {
 pub struct TreeCache {
     folding_schedule: Vec<usize>,
     fri_lde_degree: usize,
-    trace_subtrees: Vec<SubTree>,
-    argument_subtrees: Vec<SubTree>,
-    setup_subtrees: Vec<SubTree>,
-    quotient_subtrees: Vec<SubTree>,
+    // trace_subtrees: Vec<SubTree>,
+    // argument_subtrees: Vec<SubTree>,
+    // setup_subtrees: Vec<SubTree>,
+    // quotient_subtrees: Vec<SubTree>,
     storage: HashMap<OracleType, Vec<SubTree>>,
 }
 
@@ -40,10 +40,10 @@ impl TreeCache {
         Self {
             folding_schedule: vec![],
             fri_lde_degree,
-            trace_subtrees: vec![],
-            argument_subtrees: vec![],
-            setup_subtrees: vec![],
-            quotient_subtrees: vec![],
+            // trace_subtrees: vec![],
+            // argument_subtrees: vec![],
+            // setup_subtrees: vec![],
+            // quotient_subtrees: vec![],
             storage: HashMap::new(),
         }
     }
@@ -87,19 +87,19 @@ impl TreeCache {
         unimplemented!()
     }
 
-    pub fn setup_setup_subtrees(&mut self, subtrees: Vec<SubTree>) {
-        assert_eq!(subtrees.len(), self.fri_lde_degree);
-        assert!(self.storage.insert(OracleType::Setup, subtrees).is_none())
-    }
+    // pub fn setup_setup_subtrees(&mut self, subtrees: Vec<SubTree>) {
+    //     assert_eq!(subtrees.len(), self.fri_lde_degree);
+    //     assert!(self.storage.insert(OracleType::Setup, subtrees).is_none())
+    // }
 
-    #[allow(dead_code)]
-    pub fn get_setup_subtrees(&self) -> &Vec<SubTree> {
-        self.get(OracleType::Setup)
-    }
+    // #[allow(dead_code)]
+    // pub fn get_setup_subtrees(&self) -> &Vec<SubTree> {
+    //     self.get(OracleType::Setup)
+    // }
 
-    pub fn get_setup_subtree(&self, coset_idx: usize) -> &SubTree {
-        self.get_coset_subtree(OracleType::Setup, coset_idx)
-    }
+    // pub fn get_setup_subtree(&self, coset_idx: usize) -> &SubTree {
+    //     self.get_coset_subtree(OracleType::Setup, coset_idx)
+    // }
 
     pub fn set_quotient_subtrees(&mut self, subtrees: Vec<SubTree>) {
         assert_eq!(subtrees.len(), self.fri_lde_degree);

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -30,7 +30,7 @@ use crate::{
     cs::PACKED_PLACEHOLDER_BITMASK,
 };
 
-use nvtx::{range_push, range_pop};
+use nvtx::{range_pop, range_push};
 
 use super::*;
 

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -1042,7 +1042,7 @@ fn gpu_prove_from_trace<
     );
 
     // TODO: consider to do setup query on the host
-    let (_setup_subtrees, setup_tree_cap) = setup_holder.commit::<H>(cap_size)?;
+    let setup_tree_cap = &setup_holder.fri_oracles_cap;
     assert_eq!(&setup_base.setup_tree.get_cap(), setup_tree_cap);
     // tree_holder.setup_setup_subtrees(setup_subtrees);
     // tree_holder.set_setup_tree_from_host_data(&setup_base.setup_tree);

--- a/src/test.rs
+++ b/src/test.rs
@@ -40,7 +40,7 @@ use boojum::{
 
 use boojum::field::traits::field_like::PrimeFieldLikeVectorized;
 
-use nvtx::{range_push, range_pop};
+use nvtx::{range_pop, range_push};
 
 #[allow(dead_code)]
 pub type DefaultDevCS = CSReferenceAssembly<F, F, DevCSConfig>;
@@ -938,7 +938,8 @@ mod zksync {
                 let gpu_proof = {
                     let mut proving_cs =
                         synth_circuit_for_proving(circuit.clone(), &finalization_hint);
-                    let mut setup_cache = SetupCache::new(&gpu_setup, &proof_config, &proving_cs).unwrap();
+                    let mut setup_cache =
+                        SetupCache::new(&gpu_setup, &proof_config, &proving_cs).unwrap();
                     gpu_prove::<_, DefaultTranscript, DefaultTreeHasher, NoPow, Global>(
                         &mut proving_cs,
                         proof_config,
@@ -1078,7 +1079,8 @@ mod zksync {
             &worker,
         )
         .expect("gpu setup");
-        let mut setup_cache = SetupCache::new(&gpu_setup, &proof_cfg, &proving_cs).expect("setup cache");
+        let mut setup_cache =
+            SetupCache::new(&gpu_setup, &proof_cfg, &proving_cs).expect("setup cache");
         let gpu_proof = {
             gpu_prove::<_, DefaultTranscript, DefaultTreeHasher, NoPow, Global>(
                 &mut proving_cs,
@@ -1121,7 +1123,9 @@ mod zksync {
     #[test]
     #[ignore]
     fn compare_proofs_with_external_synthesis_for_single_zksync_circuit_in_single_shot() {
-        range_push!("compare_proofs_with_external_synthesis_for_single_zksync_circuit_in_single_shot");
+        range_push!(
+            "compare_proofs_with_external_synthesis_for_single_zksync_circuit_in_single_shot"
+        );
 
         let circuit = get_circuit_from_env();
         let _ctx = ProverContext::create().expect("gpu prover context");
@@ -1168,7 +1172,8 @@ mod zksync {
             let reusable_cs = init_cs_for_external_proving(circuit.clone(), &finalization_hint);
             range_pop!();
             range_push!("SetupCache::new(&gpu_setup, &proof_cfg, &reusable_cs");
-            let mut setup_cache = SetupCache::new(&gpu_setup, &proof_cfg, &reusable_cs).expect("setup cache");
+            let mut setup_cache =
+                SetupCache::new(&gpu_setup, &proof_cfg, &reusable_cs).expect("setup cache");
             range_pop!();
             gpu_prove_from_external_witness_data::<
                 _,
@@ -1254,7 +1259,8 @@ mod zksync {
             &worker,
         )
         .expect("gpu setup");
-        let mut setup_cache = SetupCache::new(&gpu_setup, &proof_config, &proving_cs).expect("setup cache");
+        let mut setup_cache =
+            SetupCache::new(&gpu_setup, &proof_config, &proving_cs).expect("setup cache");
         witness.public_inputs_locations = vec![(0, 0)];
         gpu_setup.variables_hint[0][0] = 1 << 31;
         let _ = gpu_prove_from_external_witness_data::<


### PR DESCRIPTION
# What ❔

Adds option to use an externally cached on-device setup (permutation polys, lookup tables, constant cols) across multiple invocations of the prover.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

In current code the on-device setup is reconstructed each time the prover is invoked. Materializing the setup (especially permutation polys) is expensive, around 280-290 ms. But in principle we can often avoid this: each prover instance typically handles a small number of circuits and can be configured to prove the same circuit multiple times in succession, in which case we can reuse the setup across proofs.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
