### PR TITLE
Adapt to changes introduced by the CUDA execution refactoring in boojum-cuda

### DIFF
--- a/src/primitives/arith.rs
+++ b/src/primitives/arith.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use boojum_cuda::device_structures::{DeviceMatrix, DeviceMatrixMut};
+use boojum_cuda::device_structures::{DeviceMatrix, DeviceMatrixMut, Vectorized};
 use boojum_cuda::extension_field::VectorizedExtensionField;
 // arithmetic operations
 use boojum_cuda::ops_cub::device_scan::*;
@@ -483,7 +483,7 @@ pub fn barycentric_evaluate_ext_at_ext<A: GoodAllocator>(
 }
 
 fn barycentric_evaluate<E: boojum_cuda::barycentric::EvalImpl, A: GoodAllocator>(
-    values: &[E::YsVec],
+    values: &[<E::Y as Vectorized>::Type],
     bases: &[F],
     domain_size: usize,
     num_polys: usize,


### PR DESCRIPTION
# What ❔

This PR adapts the code to changes introduced by the CUDA execution refactoring in boojum-cuda in this PR: https://github.com/matter-labs/era-boojum-cuda/pull/21

## Why ❔

API change in boojum-cuda requires a change in the caller code.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted via `cargo fmt` and checked with `cargo check`.
