### PR TITLE
improve allocator stats

### DIFF
--- a/src/prover.rs
+++ b/src/prover.rs
@@ -1092,11 +1092,13 @@ fn gpu_prove_from_trace<
     println!("FRI Queries are done {:?}", time.elapsed());
     #[cfg(feature = "allocator_stats")]
     unsafe {
-        dbg!(_DEVICE_ALLOCATOR.as_ref().unwrap().get_allocation_stats());
-        dbg!(_SMALL_DEVICE_ALLOCATOR
+        dbg!(_DEVICE_ALLOCATOR
             .as_ref()
             .unwrap()
-            .get_allocation_stats());
+            .stats
+            .lock()
+            .unwrap()
+            .print(false));
     }
 
     gpu_proof.public_inputs = public_inputs;

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -1098,7 +1098,7 @@ fn gpu_prove_from_trace<
             .stats
             .lock()
             .unwrap()
-            .print(true);
+            .print(true, true);
     }
 
     gpu_proof.public_inputs = public_inputs;

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -1092,13 +1092,13 @@ fn gpu_prove_from_trace<
     println!("FRI Queries are done {:?}", time.elapsed());
     #[cfg(feature = "allocator_stats")]
     unsafe {
-        dbg!(_DEVICE_ALLOCATOR
+        _DEVICE_ALLOCATOR
             .as_ref()
             .unwrap()
             .stats
             .lock()
             .unwrap()
-            .print(false));
+            .print(true);
     }
 
     gpu_proof.public_inputs = public_inputs;


### PR DESCRIPTION
# What ❔

This PR improves the implementation of allocator statistics and adds the capability to capture the allocation stacktrace.

## Why ❔

Map of allocations with stacktraces is helpful.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted via `cargo fmt` and checked with`cargo check`.
