### PR TITLE
Memcopy/memset housekeeping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,6 @@ derivative = "*"
 bincode = "*"
 serde = { version = "1.0", features = ["derive"] }
 
-nvtx = "1.2"
-
 
 [dev-dependencies]
 serial_test = "^2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ derivative = "*"
 bincode = "*"
 serde = { version = "1.0", features = ["derive"] }
 
+nvtx = "1.2"
+
 
 [dev-dependencies]
 serial_test = "^2"

--- a/src/copy_permutation.rs
+++ b/src/copy_permutation.rs
@@ -151,7 +151,7 @@ where
         rhs.push(p);
     }
     assert_eq!(lhs.len(), rhs.len());
-    let omega_values = ComplexPoly::<CosetEvaluations>::from_real(omega_values.clone())?;
+    let omega_values = ComplexPoly::<CosetEvaluations>::from_real(omega_values)?;
 
     for (
         ((((existing_lhs, existing_rhs), variable_cols_chunk), sigma_cols_chunk), alpha),
@@ -180,7 +180,7 @@ where
             current_num.add_constant(&gamma)?;
 
             // dnumerator w + beta * sigma(x) + gamma
-            let mut current_denum = ComplexPoly::<CosetEvaluations>::from_real(sigma_col.clone())?;
+            let mut current_denum = ComplexPoly::<CosetEvaluations>::from_real(sigma_col)?;
             current_denum.scale_real(&beta)?;
             current_denum.add_assign_real(&variable_col)?;
             current_denum.add_constant(&gamma)?;

--- a/src/copy_permutation.rs
+++ b/src/copy_permutation.rs
@@ -37,9 +37,8 @@ pub fn compute_partial_products(
     helpers::set_value(z_poly.c0.storage.as_mut(), &DF::one()?)?;
     helpers::set_zero(z_poly.c1.storage.as_mut())?;
 
-    // TODO: allocate two empty arrays?
-    let mut num: ComplexPoly<LagrangeBasis> = ComplexPoly::zero(domain_size)?;
-    let mut denum: ComplexPoly<LagrangeBasis> = ComplexPoly::zero(domain_size)?;
+    let mut num: ComplexPoly<LagrangeBasis> = ComplexPoly::empty(domain_size)?;
+    let mut denum: ComplexPoly<LagrangeBasis> = ComplexPoly::empty(domain_size)?;
 
     // The "max opt" pattern here would look like some fully fused kernel followed by
     // a single batch inverse followed by another fused kernel.
@@ -69,7 +68,6 @@ pub fn compute_partial_products(
             num_cols_per_product,
             domain_size,
         )?;
-        // TODO use batch inverse
         denum.inverse()?;
         num.mul_assign(&denum)?;
 

--- a/src/dvec.rs
+++ b/src/dvec.rs
@@ -194,7 +194,7 @@ impl<T> DVec<T, StaticDeviceAllocator> {
         let mut data = Vec::with_capacity_in(padded_cap, alloc);
         unsafe {
             data.set_len(cap);
-            helpers::set_zero_generic(&mut data).expect("zeroize");
+            // helpers::set_zero_generic(&mut data).expect("zeroize");
         }
         Self { data }
     }
@@ -304,7 +304,7 @@ impl<T> SVec<T> {
 
         let mut data = Vec::with_capacity_in(padded_cap, alloc);
         unsafe {
-            helpers::set_zero_generic(&mut data).expect("zeroize");
+            // helpers::set_zero_generic(&mut data).expect("zeroize");
             data.set_len(cap);
         }
         Self { data }

--- a/src/dvec.rs
+++ b/src/dvec.rs
@@ -156,7 +156,7 @@ impl<T, A: StaticAllocator> DVec<T, A> {
 
 impl DVec<F> {
     pub fn get(&self, pos: usize) -> CudaResult<DF> {
-        let mut el = DF::zero()?;
+        let mut el = DF::empty()?;
         mem::d2d(&self.data[pos..pos + 1], &mut el.inner[..])?;
         Ok(el)
     }
@@ -330,7 +330,7 @@ pub struct DF {
 
 impl Clone for DF {
     fn clone(&self) -> Self {
-        let mut new = Self::zero().unwrap();
+        let mut new = Self::empty().unwrap();
         new.inner
             .copy_from_device_slice(&self.inner)
             .expect("copy device value");
@@ -353,39 +353,45 @@ impl DF {
         _small_alloc().clone()
     }
 
+    pub fn empty() -> CudaResult<Self> {
+        let mut storage = svec!(1);
+
+        Ok(Self { inner: storage })
+    }
+
     pub fn zero() -> CudaResult<Self> {
         let mut storage = svec!(1);
-        storage.copy_from_slice(&[F::ZERO])?;
+        helpers::set_by_value(storage.as_mut(), F::ZERO, get_stream())?;
 
         Ok(Self { inner: storage })
     }
 
     pub fn one() -> CudaResult<Self> {
-        let mut this = Self::zero()?;
-        this.copy_from_host_value(&F::ONE)?;
+        let mut storage = svec!(1);
+        helpers::set_by_value(storage.as_mut(), F::ONE, get_stream())?;
 
-        Ok(this)
+        Ok(Self { inner: storage })
     }
 
     pub fn non_residue() -> CudaResult<Self> {
         let non_residue = F::from_raw_u64_unchecked(7);
-        let mut this = Self::zero()?;
-        this.copy_from_host_value(&non_residue)?;
+        let mut storage = svec!(1);
+        helpers::set_by_value(storage.as_mut(), non_residue, get_stream())?;
 
-        Ok(this)
+        Ok(Self { inner: storage })
     }
 
     pub fn copy_from_host_value(&mut self, value: &F) -> CudaResult<()> {
-        self.inner.copy_from_slice(&[*value])?;
+        helpers::set_by_value(self.inner.as_mut(), value.clone(), get_stream())?;
 
         Ok(())
     }
 
     pub fn from_host_value(value: &F) -> CudaResult<Self> {
-        let mut this = Self::zero()?;
-        this.inner.copy_from_slice(&[*value])?;
+        let mut storage = svec!(1);
+        helpers::set_by_value(storage.as_mut(), value.clone(), get_stream())?;
 
-        Ok(this)
+        Ok(Self { inner: storage })
     }
 
     pub fn as_mut_ptr(&mut self) -> *mut F {
@@ -402,7 +408,7 @@ impl Into<F> for DF {
 
 impl From<F> for DF {
     fn from(value: F) -> Self {
-        let mut this = Self::zero().expect("");
+        let mut this = Self::empty().expect("");
         this.copy_from_host_value(&value).expect("");
         this
     }
@@ -410,7 +416,7 @@ impl From<F> for DF {
 
 impl From<&F> for DF {
     fn from(value: &F) -> Self {
-        let mut this = Self::zero().expect("");
+        let mut this = Self::empty().expect("");
         this.copy_from_host_value(value).expect("");
         this
     }
@@ -433,6 +439,13 @@ impl Clone for DExt {
 impl DExt {
     pub fn new(c0: DF, c1: DF) -> Self {
         Self { c0, c1 }
+    }
+
+    pub fn empty() -> CudaResult<Self> {
+        let c0 = DF::empty()?;
+        let c1 = DF::empty()?;
+
+        Ok(Self { c0, c1 })
     }
 
     pub fn zero() -> CudaResult<Self> {
@@ -474,7 +487,7 @@ impl Into<EF> for DExt {
 
 impl From<EF> for DExt {
     fn from(value: EF) -> Self {
-        let mut this = Self::zero().expect("");
+        let mut this = Self::empty().expect("");
         this.copy_from_host_value(&value).expect("");
         this
     }
@@ -482,7 +495,7 @@ impl From<EF> for DExt {
 
 impl From<&EF> for DExt {
     fn from(value: &EF) -> Self {
-        let mut this = Self::zero().expect("");
+        let mut this = Self::empty().expect("");
         this.copy_from_host_value(value).expect("");
         this
     }

--- a/src/dvec.rs
+++ b/src/dvec.rs
@@ -354,7 +354,7 @@ impl DF {
     }
 
     pub fn empty() -> CudaResult<Self> {
-        let mut storage = svec!(1);
+        let storage = svec!(1);
 
         Ok(Self { inner: storage })
     }
@@ -448,6 +448,7 @@ impl DExt {
         Ok(Self { c0, c1 })
     }
 
+    #[allow(dead_code)]
     pub fn zero() -> CudaResult<Self> {
         let c0 = DF::zero()?;
         let c1 = DF::zero()?;

--- a/src/lookup.rs
+++ b/src/lookup.rs
@@ -91,7 +91,7 @@ pub fn compute_lookup_argument_over_specialized_cols(
 
     // aggregate table values
     assert_eq!(table_cols.len(), powers_of_gamma.len());
-    let mut aggregated_table_values = ComplexPoly::<LagrangeBasis>::zero(domain_size)?;
+    let mut aggregated_table_values = ComplexPoly::<LagrangeBasis>::empty(domain_size)?;
     lookup_aggregated_table_values(
         &table_cols,
         &beta,

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -148,6 +148,15 @@ impl<'a, P: PolyForm> Poly<'a, P> {
             PolyStorage::Owned(_) => true,
         }
     }
+
+    pub fn empty(domain_size: usize) -> CudaResult<Self> {
+        let storage = dvec!(domain_size);
+        Ok(Self {
+            storage: PolyStorage::Owned(storage),
+            marker: std::marker::PhantomData,
+        })
+    }
+
     pub fn zero(domain_size: usize) -> CudaResult<Self> {
         let mut storage = dvec!(domain_size);
         helpers::set_zero(&mut storage)?;
@@ -249,6 +258,20 @@ impl<'a, P: PolyForm> ComplexPoly<'a, P> {
         c0 && c1
     }
 
+    pub fn empty(domain_size: usize) -> CudaResult<Self> {
+        let mut chunks = dvec!(2 * domain_size)
+            .into_adjacent_chunks(domain_size)
+            .into_iter();
+        let c0 = chunks.next().unwrap();
+        let c1 = chunks.next().unwrap();
+        assert!(chunks.next().is_none());
+
+        Ok(Self {
+            c0: Poly::from(c0),
+            c1: Poly::from(c1),
+        })
+    }
+
     pub fn zero(domain_size: usize) -> CudaResult<Self> {
         let mut chunks = dvec!(2 * domain_size)
             .into_adjacent_chunks(domain_size)
@@ -264,6 +287,7 @@ impl<'a, P: PolyForm> ComplexPoly<'a, P> {
             c1: Poly::from(c1),
         })
     }
+
     pub fn one(domain_size: usize) -> CudaResult<Self> {
         let mut chunks = dvec!(2 * domain_size)
             .into_adjacent_chunks(domain_size)
@@ -529,10 +553,7 @@ macro_rules! impl_common_poly {
 
             #[allow(dead_code)]
             pub fn sub_assign<'b>(&mut self, other: &Poly<'b, $form>) -> CudaResult<()> {
-                let mut other = other.clone();
-                other.negate()?;
-                // arith::sub_assign(self.storage.as_mut(), other.storage.as_ref())
-                arith::add_assign(self.storage.as_mut(), other.storage.as_ref())
+                arith::sub_assign(self.storage.as_mut(), other.storage.as_ref())
             }
 
             #[allow(dead_code)]
@@ -554,10 +575,7 @@ macro_rules! impl_common_poly {
 
             #[allow(dead_code)]
             pub fn sub_constant(&mut self, value: &DF) -> CudaResult<()> {
-                let mut h_value: F = value.clone().into();
-                h_value.negate();
-                let value: DF = h_value.into();
-                arith::add_constant(self.storage.as_mut(), &value)
+                arith::sub_constant(self.storage.as_mut(), &value)
             }
 
             #[allow(dead_code)]
@@ -672,6 +690,16 @@ macro_rules! impl_common_complex_poly {
                 self.c1.mul_assign(&other.c0)?;
                 self.c1.add_assign(&self.c0)?;
                 mem::d2d(&t0.storage.as_ref(), self.c0.storage.as_mut())?;
+
+                Ok(())
+            }
+
+            #[allow(dead_code)]
+            pub fn mul_assign_real<'b>(&mut self, other: &Poly<'b, $form>) -> CudaResult<()> {
+                assert_eq!(self.c0.storage.len(), other.storage.len());
+                assert_eq!(self.c1.storage.len(), other.storage.len());
+                self.c0.mul_assign(&other)?;
+                self.c1.mul_assign(&other)?;
 
                 Ok(())
             }

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -617,7 +617,7 @@ macro_rules! impl_common_complex_poly {
     ($form:tt) => {
         impl<'a> ComplexPoly<'a, $form> {
             #[allow(dead_code)]
-            pub fn from_real(c0: Poly<'a, $form>) -> CudaResult<ComplexPoly<'a, $form>> {
+            pub fn from_real(c0: &Poly<'a, $form>) -> CudaResult<ComplexPoly<'a, $form>> {
                 assert!(c0.is_owned());
                 let domain_size = c0.storage.len();
                 assert!(domain_size.is_power_of_two());

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -569,22 +569,12 @@ macro_rules! impl_common_complex_poly {
 
             #[allow(dead_code)]
             pub fn mul_assign<'b>(&mut self, other: &ComplexPoly<'b, $form>) -> CudaResult<()> {
-                let non_residue = DF::non_residue()?;
-
-                let mut t0 = self.c0.clone();
-                let mut t1 = self.c1.clone();
-
-                t0.mul_assign(&other.c0)?;
-                t1.mul_assign(&other.c1)?;
-                t1.scale(&non_residue)?;
-                t0.add_assign(&t1)?;
-
-                self.c0.mul_assign(&other.c1)?;
-                self.c1.mul_assign(&other.c0)?;
-                self.c1.add_assign(&self.c0)?;
-                mem::d2d(&t0.storage.as_ref(), self.c0.storage.as_mut())?;
-
-                Ok(())
+                arith::mul_assign_complex(
+                    self.c0.storage.as_mut(),
+                    self.c1.storage.as_mut(),
+                    other.c0.storage.as_ref(),
+                    other.c1.storage.as_ref(),
+                )
             }
 
             #[allow(dead_code)]

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -90,6 +90,7 @@ impl<'a> PolyStorage<'a> {
         }
     }
 
+    #[allow(dead_code)]
     pub fn copy_from_device_slice(&mut self, other: &[F]) -> CudaResult<()> {
         match self {
             PolyStorage::Borrowed(_) => unimplemented!(),
@@ -149,6 +150,7 @@ impl<'a, P: PolyForm> Poly<'a, P> {
         }
     }
 
+    #[allow(dead_code)]
     pub fn empty(domain_size: usize) -> CudaResult<Self> {
         let storage = dvec!(domain_size);
         Ok(Self {
@@ -157,6 +159,7 @@ impl<'a, P: PolyForm> Poly<'a, P> {
         })
     }
 
+    #[allow(dead_code)]
     pub fn zero(domain_size: usize) -> CudaResult<Self> {
         let mut storage = dvec!(domain_size);
         helpers::set_zero(&mut storage)?;

--- a/src/primitives/arith.rs
+++ b/src/primitives/arith.rs
@@ -435,6 +435,8 @@ pub fn precompute_barycentric_bases(
     // shift is k*w^0=k where k is multiplicative generator
 
     // The following does NOT work ("the trait `SetByVal` is not implemented" for EF)
+    // TODO: Use it if we ever add EF support for pointwise ops in boojum-cuda.
+    // For now that seems like overkill.
     // let mut d_point: DVec<EF, _> = svec!(1);
     // helpers::set_by_value(d_point.as_mut(), point, get_stream());
 
@@ -442,8 +444,8 @@ pub fn precompute_barycentric_bases(
     // It's a little ugly but avoids potentially synchronizing copies.
     let mut coeffs: DVec<F, _> = svec!(2);
     let [c0, c1] = point.into_coeffs_in_base();
-    helpers::set_by_value(coeffs[..1].as_mut(), c0, get_stream());
-    helpers::set_by_value(coeffs[1..].as_mut(), c1, get_stream());
+    helpers::set_by_value(coeffs[..1].as_mut(), c0, get_stream())?;
+    helpers::set_by_value(coeffs[1..].as_mut(), c1, get_stream())?;
     let d_point_ef = unsafe { std::slice::from_raw_parts(coeffs.as_ptr() as *const EF, 1) };
     let d_point_ef_var = unsafe { DeviceVariable::from_ref(&d_point_ef[0]) };
 

--- a/src/primitives/arith.rs
+++ b/src/primitives/arith.rs
@@ -18,7 +18,6 @@ pub fn add_assign(this: &mut [F], other: &[F]) -> CudaResult<()> {
     add_into_x(this, other, get_stream())
 }
 
-#[allow(dead_code)]
 pub fn sub_assign(this: &mut [F], other: &[F]) -> CudaResult<()> {
     assert_eq!(this.len(), other.len());
     let (this, other) = unsafe {

--- a/src/primitives/arith.rs
+++ b/src/primitives/arith.rs
@@ -56,8 +56,7 @@ pub fn mul_assign_complex(
         assert_eq!(c0_this_ptr.add(domain_size), c1_this.as_ptr());
     }
     let this_ptr = c0_this_ptr as *mut VEF;
-    let mut this_slice: &mut [VEF] =
-        unsafe { slice::from_raw_parts_mut(this_ptr, domain_size) };
+    let mut this_slice: &mut [VEF] = unsafe { slice::from_raw_parts_mut(this_ptr, domain_size) };
     let this_vector = unsafe { DeviceSlice::from_mut_slice(&mut this_slice) };
 
     let c0_other_ptr = c0_other.as_ptr();
@@ -65,8 +64,7 @@ pub fn mul_assign_complex(
         assert_eq!(c0_other_ptr.add(domain_size), c1_other.as_ptr());
     }
     let other_ptr = c0_other_ptr as *const VEF;
-    let other_slice: &[VEF] =
-        unsafe { slice::from_raw_parts(other_ptr, domain_size) };
+    let other_slice: &[VEF] = unsafe { slice::from_raw_parts(other_ptr, domain_size) };
     let other_vector = unsafe { DeviceSlice::from_slice(&other_slice) };
 
     mul_into_x(this_vector, other_vector, get_stream())
@@ -435,24 +433,34 @@ pub fn precompute_barycentric_bases(
     // (X^N - 1)/ N
     // evaluations are elems of first coset of the lde
     // shift is k*w^0=k where k is multiplicative generator
-    let mut d_point = svec!(1);
-    d_point.copy_from_slice(&[point])?;
+
+    // The following does NOT work ("the trait `SetByVal` is not implemented" for EF)
+    // let mut d_point: DVec<EF, _> = svec!(1);
+    // helpers::set_by_value(d_point.as_mut(), point, get_stream());
+
+    // The following sequence creates a &DeviceVariable<EF> for point.
+    // It's a little ugly but avoids potentially synchronizing copies.
+    let mut coeffs: DVec<F, _> = svec!(2);
+    let [c0, c1] = point.into_coeffs_in_base();
+    helpers::set_by_value(coeffs[..1].as_mut(), c0, get_stream());
+    helpers::set_by_value(coeffs[1..].as_mut(), c1, get_stream());
+    let d_point_ef = unsafe { std::slice::from_raw_parts(coeffs.as_ptr() as *const EF, 1) };
+    let d_point_ef_var = unsafe { DeviceVariable::from_ref(&d_point_ef[0]) };
 
     let mut d_tmp: SVec<EF> = svec!(1);
 
-    let (bases, point, common_factor_storage) = unsafe {
-        let point = &d_point[0];
-        let tmp_point = &mut d_tmp[0];
+    let (bases, common_factor_storage) = unsafe {
         let v_bases = std::slice::from_raw_parts_mut(bases.as_ptr() as *mut _, domain_size);
+        let tmp_point = &mut d_tmp[0];
         (
             DeviceSlice::from_mut_slice(v_bases),
-            DeviceVariable::from_ref(point),
             DeviceVariable::from_mut(tmp_point),
         )
     };
+
     use boojum_cuda::barycentric::PrecomputeAtExt;
     boojum_cuda::barycentric::precompute_lagrange_coeffs::<PrecomputeAtExt>(
-        point,
+        d_point_ef_var,
         common_factor_storage,
         coset,
         bases,

--- a/src/primitives/helpers.rs
+++ b/src/primitives/helpers.rs
@@ -98,7 +98,6 @@ pub fn set_value_generic<T: SetByRef>(buffer: &mut [T], value: &T) -> CudaResult
     set_by_ref(value, buffer, get_stream())
 }
 
-#[allow(dead_code)]
 pub fn set_by_value<T: SetByVal>(
     buffer: &mut [T],
     value: T,
@@ -114,6 +113,7 @@ pub fn set_zero(buffer: &mut [F]) -> CudaResult<()> {
     set_to_zero(buffer, get_stream())
 }
 
+#[allow(dead_code)]
 pub fn set_zero_generic<T>(buffer: &mut [T]) -> CudaResult<()> {
     let buffer = unsafe { DeviceSlice::from_mut_slice(buffer) };
     set_to_zero(buffer, get_stream())

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -699,7 +699,7 @@ fn gpu_prove_from_trace<
     let general_purpose_cols_challenge_power_offset =
         total_num_lookup_argument_terms + total_num_gate_terms_for_specialized_columns;
     for coset_idx in 0..quotient_degree {
-        let mut coset_values = ComplexPoly::<CosetEvaluations>::zero(domain_size)?;
+        let mut coset_values = ComplexPoly::<CosetEvaluations>::empty(domain_size)?;
         let trace_coset_values = trace_holder.get_or_compute_coset_evals(coset_idx)?;
         let setup_coset_values = setup_holder.get_or_compute_coset_evals(coset_idx)?;
         let argument_coset_values = argument_holder.get_or_compute_coset_evals(coset_idx)?;

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -32,8 +32,6 @@ use crate::{
 
 use super::*;
 
-use nvtx::{range_pop, range_push};
-
 pub fn gpu_prove_from_external_witness_data<
     P: boojum::field::traits::field_like::PrimeFieldLikeVectorized<Base = F>,
     TR: Transcript<F, CompatibleCap = [F; 4]>,
@@ -702,12 +700,9 @@ fn gpu_prove_from_trace<
         total_num_lookup_argument_terms + total_num_gate_terms_for_specialized_columns;
     for coset_idx in 0..quotient_degree {
         let mut coset_values = ComplexPoly::<CosetEvaluations>::empty(domain_size)?;
-        range_push!("get_or_compute_coset_evals");
         let trace_coset_values = trace_holder.get_or_compute_coset_evals(coset_idx)?;
         let setup_coset_values = setup_holder.get_or_compute_coset_evals(coset_idx)?;
         let argument_coset_values = argument_holder.get_or_compute_coset_evals(coset_idx)?;
-        range_pop!();
-        range_push!("compute_quotient_by_coset");
         compute_quotient_by_coset(
             &trace_coset_values,
             &setup_coset_values,
@@ -735,7 +730,6 @@ fn gpu_prove_from_trace<
             variables_offset,
             &mut coset_values,
         )?;
-        range_pop!();
 
         let start = coset_idx * domain_size;
         let end = start + domain_size;

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -32,6 +32,8 @@ use crate::{
 
 use super::*;
 
+use nvtx::{range_push, range_pop};
+
 pub fn gpu_prove_from_external_witness_data<
     P: boojum::field::traits::field_like::PrimeFieldLikeVectorized<Base = F>,
     TR: Transcript<F, CompatibleCap = [F; 4]>,
@@ -700,9 +702,12 @@ fn gpu_prove_from_trace<
         total_num_lookup_argument_terms + total_num_gate_terms_for_specialized_columns;
     for coset_idx in 0..quotient_degree {
         let mut coset_values = ComplexPoly::<CosetEvaluations>::empty(domain_size)?;
+        range_push!("get_or_compute_coset_evals");
         let trace_coset_values = trace_holder.get_or_compute_coset_evals(coset_idx)?;
         let setup_coset_values = setup_holder.get_or_compute_coset_evals(coset_idx)?;
         let argument_coset_values = argument_holder.get_or_compute_coset_evals(coset_idx)?;
+        range_pop!();
+        range_push!("compute_quotient_by_coset");
         compute_quotient_by_coset(
             &trace_coset_values,
             &setup_coset_values,
@@ -730,6 +735,7 @@ fn gpu_prove_from_trace<
             variables_offset,
             &mut coset_values,
         )?;
+        range_pop!();
 
         let start = coset_idx * domain_size;
         let end = start + domain_size;

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -32,7 +32,7 @@ use crate::{
 
 use super::*;
 
-use nvtx::{range_push, range_pop};
+use nvtx::{range_pop, range_push};
 
 pub fn gpu_prove_from_external_witness_data<
     P: boojum::field::traits::field_like::PrimeFieldLikeVectorized<Base = F>,


### PR DESCRIPTION
# What ❔

(mostly) simple changes to streamline arithmetic, (mostly) to eliminate unneeded memcopies and memsets

## Why ❔

Cleaner code and improved performance
Each change is minor but the overall effect is >10% end to end speedup.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and `cargo lint`.
