### PR TITLE
use PACKED_PLACEHOLDER_BITMASK constant instead of raw value

### DIFF
--- a/src/prover.rs
+++ b/src/prover.rs
@@ -99,7 +99,7 @@ pub fn gpu_prove_from_external_witness_data<
     {
         let variable_idx = setup.variables_hint[col][row].clone() as usize;
         assert_eq!(
-            variable_idx & (1 << 31),
+            variable_idx & (PACKED_PLACEHOLDER_BITMASK as usize),
             0,
             "placeholder found in a public input location"
         );

--- a/src/test.rs
+++ b/src/test.rs
@@ -747,11 +747,13 @@ mod zksync {
 
     use super::*;
 
+    use crate::cs::PACKED_PLACEHOLDER_BITMASK;
     use boojum::cs::implementations::fast_serialization::MemcopySerializable;
     use circuit_definitions::{
         aux_definitions::witness_oracle::VmWitnessOracle,
         circuit_definitions::base_layer::ZkSyncBaseLayerCircuit, ZkSyncDefaultRoundFunction,
     };
+
     pub type ZksyncProof = Proof<F, DefaultTreeHasher, GoldilocksExt2>;
 
     const TEST_DATA_ROOT_DIR: &str = "./test_data";
@@ -1213,7 +1215,7 @@ mod zksync {
         )
         .expect("gpu setup");
         witness.public_inputs_locations = vec![(0, 0)];
-        gpu_setup.variables_hint[0][0] = 1 << 31;
+        gpu_setup.variables_hint[0][0] = PACKED_PLACEHOLDER_BITMASK;
         let _ = gpu_prove_from_external_witness_data::<
             _,
             DefaultTranscript,


### PR DESCRIPTION
# What ❔

This PR replaces raw values with the PACKED_PLACEHOLDER_BITMASK constant.

## Why ❔

Improves code quality .

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo check`.
