### PR TITLE
Fixes ComplexPoly::clone() to ensure c0 and c1 are adjacent in memory

### DIFF
--- a/src/poly.rs
+++ b/src/poly.rs
@@ -194,10 +194,8 @@ pub struct ComplexPoly<'a, P: PolyForm> {
 
 impl<'a, P: PolyForm> Clone for ComplexPoly<'a, P> {
     fn clone(&self) -> Self {
-        let domain_size = self.len();
-        assert!(domain_size.is_power_of_two());
         // Uses expect, like PolyStorage::clone. We can't return a Result<Self> here unfortunately.
-        let mut new = ComplexPoly::<P>::empty(domain_size).expect("empty");
+        let mut new = ComplexPoly::<P>::empty(self.domain_size()).expect("empty");
         mem::d2d(self.as_single_slice(), new.as_single_slice_mut()).expect("clone");
 
         new
@@ -206,7 +204,9 @@ impl<'a, P: PolyForm> Clone for ComplexPoly<'a, P> {
 
 impl<'a, P: PolyForm> AsSingleSlice for ComplexPoly<'a, P> {
     fn domain_size(&self) -> usize {
-        self.c0.domain_size()
+        let domain_size = self.c0.domain_size();
+        assert!(domain_size.is_power_of_two());
+        domain_size
     }
 
     fn num_polys(&self) -> usize {
@@ -251,7 +251,7 @@ impl<'a, P: PolyForm> From<&'a [F]> for Poly<'a, P> {
 impl<'a, P: PolyForm> ComplexPoly<'a, P> {
     fn assert_c0_c1_adjacent(c0: &Poly<'a, P>, c1: &Poly<'a, P>) {
         let c0_ptr = c0.storage.as_ref().as_ptr();
-        let c0_len = c0.storage.len();
+        let c0_len = c0.domain_size();
         assert_eq!(c0_len, c1.storage.len());
         unsafe {
             assert_eq!(c0_ptr.add(c0_len), c1.storage.as_ref().as_ptr());

--- a/src/test.rs
+++ b/src/test.rs
@@ -1113,7 +1113,6 @@ mod zksync {
     fn compare_proofs_with_external_synthesis_for_single_zksync_circuit_in_single_shot() {
         let circuit = get_circuit_from_env();
         let _ctx = ProverContext::create().expect("gpu prover context");
-        // let _ctx = ProverContext::create_limited().expect("gpu prover context");
 
         println!(
             "{} {}",

--- a/src/test.rs
+++ b/src/test.rs
@@ -1113,6 +1113,7 @@ mod zksync {
     fn compare_proofs_with_external_synthesis_for_single_zksync_circuit_in_single_shot() {
         let circuit = get_circuit_from_env();
         let _ctx = ProverContext::create().expect("gpu prover context");
+        // let _ctx = ProverContext::create_limited().expect("gpu prover context");
 
         println!(
             "{} {}",


### PR DESCRIPTION
## Why ❔

Sait saw mysterious failures of [these checks](https://github.com/matter-labs/era-shivini/blob/2ad8c0430edcbf372015351792ba833b0d7af367/src/primitives/arith.rs#L56-L64) for certain circuits, indicating that for some ComplexPoly instances, c0 and c1 columns were not adjacent in memory as required by boojum-cuda. The present PR fixes the issue.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and `cargo lint`.
