### PR TITLE
[WIP] L2-friendly chunking for batched NTTs and batched NTT+bitreverse sequences

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ edition = "2021"
 # circuit_definitions = { path = "../era-zkevm_test_harness/circuit_definitions", package = "circuit_definitions", optional = true }
 
 boojum = { git = "https://github.com/matter-labs/era-boojum", branch = "main" }
-boojum-cuda = { git = "https://github.com/matter-labs/era-boojum-cuda", branch = "main" }
+# boojum-cuda = { git = "https://github.com/matter-labs/era-boojum-cuda", branch = "main" }
+boojum-cuda = { path = "/home/mcarilli_matterlabs_dev/era-boojum-cuda", package = "boojum-cuda" }
 cudart = { git = "https://github.com/matter-labs/era-cuda", branch = "main", package = "cudart" }
 cudart-sys = { git = "https://github.com/matter-labs/era-cuda", branch = "main", package = "cudart-sys" }
 circuit_definitions = { git = "https://github.com/matter-labs/era-zkevm_test_harness", branch = "v1.4.0", package = "circuit_definitions", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2021"
 boojum = { git = "https://github.com/matter-labs/era-boojum", branch = "main" }
 boojum-cuda = { git = "https://github.com/matter-labs/era-boojum-cuda", branch = "main" }
 cudart = { git = "https://github.com/matter-labs/era-cuda", branch = "main", package = "cudart" }
+cudart-sys = { git = "https://github.com/matter-labs/era-cuda", branch = "main", package = "cudart-sys" }
 circuit_definitions = { git = "https://github.com/matter-labs/era-zkevm_test_harness", branch = "v1.4.0", package = "circuit_definitions", optional = true }
 
 rand = "0.8"

--- a/src/context.rs
+++ b/src/context.rs
@@ -34,9 +34,16 @@ impl ProverContext {
             _HOST_ALLOCATOR = Some(host_alloc);
             _SMALL_HOST_ALLOCATOR = Some(small_host_alloc);
             _EXEC_STREAM = Some(Stream::create()?);
+            _STREAM0 = Some(Stream::create()?);
+            _STREAM1 = Some(Stream::create()?);
             _H2D_STREAM = Some(Stream::create()?);
             _D2H_STREAM = Some(Stream::create()?);
         }
+
+        // fine and coarse powers + plenty of safety margin
+        set_l2_persistence_carveout(2 * 8 * 8 * (1 << 12))?;
+        set_l2_persistence_for_twiddles(get_stream0())?;
+        set_l2_persistence_for_twiddles(get_stream1())?;
 
         Ok(Self {})
     }
@@ -189,11 +196,21 @@ impl Drop for ProverContext {
 
 pub(crate) static mut _CUDA_CONTEXT: Option<CudaContext> = None;
 pub(crate) static mut _EXEC_STREAM: Option<Stream> = None;
+pub(crate) static mut _STREAM0: Option<Stream> = None;
+pub(crate) static mut _STREAM1: Option<Stream> = None;
 pub(crate) static mut _H2D_STREAM: Option<Stream> = None;
 pub(crate) static mut _D2H_STREAM: Option<Stream> = None;
 
 pub(crate) fn get_stream() -> &'static CudaStream {
     unsafe { &_EXEC_STREAM.as_ref().expect("execution stream").inner }
+}
+
+pub(crate) fn get_stream0() -> &'static CudaStream {
+    unsafe { &_STREAM0.as_ref().expect("execution stream").inner }
+}
+
+pub(crate) fn get_stream1() -> &'static CudaStream {
+    unsafe { &_STREAM1.as_ref().expect("execution stream").inner }
 }
 
 pub(crate) fn get_h2d_stream() -> &'static CudaStream {

--- a/src/data_structures/arguments.rs
+++ b/src/data_structures/arguments.rs
@@ -221,10 +221,8 @@ impl<'a> GenericArgumentStorage<'a, MonomialBasis> {
         let l2_chunk_elems = get_l2_chunk_elems(domain_size)?;
         let mut num_cols_processed = 0;
         let main_stream = get_stream();
-        let stream0 = CudaStream::create_with_flags(CudaStreamCreateFlags::NON_BLOCKING)?;
-        let stream1 = CudaStream::create_with_flags(CudaStreamCreateFlags::NON_BLOCKING)?;
-        set_l2_persistence_for_twiddles(&stream0)?;
-        set_l2_persistence_for_twiddles(&stream1)?;
+        let stream0 = get_stream0();
+        let stream1 = get_stream1();
         let start_event = CudaEvent::create_with_flags(CudaEventCreateFlags::DISABLE_TIMING)?;
         start_event.record(&main_stream)?;
         stream0.wait_event(&start_event, CudaStreamWaitEventFlags::DEFAULT)?;
@@ -280,8 +278,6 @@ impl<'a> GenericArgumentStorage<'a, MonomialBasis> {
         main_stream.wait_event(&end_event0, CudaStreamWaitEventFlags::DEFAULT)?;
         main_stream.wait_event(&end_event1, CudaStreamWaitEventFlags::DEFAULT)?;
 
-        stream0.destroy()?;
-        stream1.destroy()?;
         end_event0.destroy()?;
         end_event1.destroy()?;
 

--- a/src/data_structures/arguments.rs
+++ b/src/data_structures/arguments.rs
@@ -159,15 +159,17 @@ impl<'a> GenericArgumentStorage<'a, LagrangeBasis> {
             ..
         } = self;
         let num_ntts = 2 * num_polys;
-        ntt::batch_ntt(
-            storage.as_single_slice_mut(),
-            false,
-            true,
-            domain_size,
-            num_ntts,
-        )?;
 
-        ntt::batch_bitreverse(storage.as_single_slice_mut(), domain_size)?;
+        let storage_slice = storage.as_single_slice_mut();
+        let l2_chunk_elems = get_l2_chunk_elems(domain_size)?;
+        let mut num_cols_processed = 0;
+        for storage_chunk in storage_slice.chunks_mut(l2_chunk_elems) {
+            let num_cols_this_chunk = storage_chunk.len() / domain_size;
+            ntt::batch_ntt(storage_chunk, false, true, domain_size, num_cols_this_chunk)?;
+            ntt::batch_bitreverse(storage_chunk, domain_size)?;
+            num_cols_processed += num_cols_this_chunk;
+        }
+        assert_eq!(num_cols_processed, num_ntts);
 
         let monomial_storage = unsafe { std::mem::transmute(storage) };
 
@@ -189,16 +191,28 @@ impl<'a> GenericArgumentStorage<'a, MonomialBasis> {
     ) -> CudaResult<()> {
         let num_polys = self.num_polys();
         let domain_size = self.domain_size();
-
         let num_coset_ffts = 2 * num_polys;
-        ntt::batch_coset_ntt_into(
-            self.storage.as_single_slice(),
-            coset_storage.storage.as_single_slice_mut(),
-            coset_idx,
-            domain_size,
-            lde_degree,
-            num_coset_ffts,
-        )?;
+
+        let storage_slice = self.storage.as_single_slice();
+        let coset_storage_slice = coset_storage.storage.as_single_slice_mut();
+        let l2_chunk_elems = get_l2_chunk_elems(domain_size)?;
+        let mut num_cols_processed = 0;
+        for (storage_chunk, coset_storage_chunk) in storage_slice
+            .chunks(l2_chunk_elems)
+            .zip(coset_storage_slice.chunks_mut(l2_chunk_elems))
+        {
+            let num_cols_this_chunk = storage_chunk.len() / domain_size;
+            ntt::batch_coset_ntt_into(
+                storage_chunk,
+                coset_storage_chunk,
+                coset_idx,
+                domain_size,
+                lde_degree,
+                num_cols_this_chunk,
+            )?;
+            num_cols_processed += num_cols_this_chunk;
+        }
+        assert_eq!(num_cols_processed, num_coset_ffts);
 
         Ok(())
     }

--- a/src/data_structures/setup.rs
+++ b/src/data_structures/setup.rs
@@ -360,10 +360,8 @@ impl GenericSetupStorage<MonomialBasis> {
         let l2_chunk_elems = get_l2_chunk_elems(domain_size)?;
         let mut num_cols_processed = 0;
         let main_stream = get_stream();
-        let stream0 = CudaStream::create_with_flags(CudaStreamCreateFlags::NON_BLOCKING)?;
-        let stream1 = CudaStream::create_with_flags(CudaStreamCreateFlags::NON_BLOCKING)?;
-        set_l2_persistence_for_twiddles(&stream0)?;
-        set_l2_persistence_for_twiddles(&stream1)?;
+        let stream0 = get_stream0();
+        let stream1 = get_stream1();
         let start_event = CudaEvent::create_with_flags(CudaEventCreateFlags::DISABLE_TIMING)?;
         start_event.record(&main_stream)?;
         stream0.wait_event(&start_event, CudaStreamWaitEventFlags::DEFAULT)?;
@@ -419,8 +417,6 @@ impl GenericSetupStorage<MonomialBasis> {
         main_stream.wait_event(&end_event0, CudaStreamWaitEventFlags::DEFAULT)?;
         main_stream.wait_event(&end_event1, CudaStreamWaitEventFlags::DEFAULT)?;
 
-        stream0.destroy()?;
-        stream1.destroy()?;
         end_event0.destroy()?;
         end_event1.destroy()?;
 

--- a/src/data_structures/setup.rs
+++ b/src/data_structures/setup.rs
@@ -5,6 +5,9 @@ use boojum::cs::{
 use std::ops::Deref;
 use std::rc::Rc;
 
+use cudart::event::{CudaEvent, CudaEventCreateFlags};
+use cudart::stream::{CudaStream, CudaStreamCreateFlags, CudaStreamWaitEventFlags};
+
 use crate::cs::{materialize_permutation_cols_from_transformed_hints_into, GpuSetup};
 
 use super::*;
@@ -331,25 +334,96 @@ impl GenericSetupStorage<MonomialBasis> {
         assert_eq!(coset_storage.domain_size(), domain_size);
         assert_eq!(coset_storage.num_polys(), num_polys);
 
+        // let storage_slice = self.storage.as_single_slice();
+        // let coset_storage_slice = coset_storage.storage.as_single_slice_mut();
+        // let l2_chunk_elems = get_l2_chunk_elems(domain_size)?;
+        // let mut num_cols_processed = 0;
+        // for (storage_chunk, coset_storage_chunk) in storage_slice
+        //     .chunks(l2_chunk_elems)
+        //     .zip(coset_storage_slice.chunks_mut(l2_chunk_elems))
+        // {
+        //     let num_cols_this_chunk = storage_chunk.len() / domain_size;
+        //     ntt::batch_coset_ntt_into(
+        //         storage_chunk,
+        //         coset_storage_chunk,
+        //         coset_idx,
+        //         domain_size,
+        //         lde_degree,
+        //         num_cols_this_chunk,
+        //     )?;
+        //     num_cols_processed += num_cols_this_chunk;
+        // }
+        // assert_eq!(num_cols_processed, num_polys);
+
         let storage_slice = self.storage.as_single_slice();
         let coset_storage_slice = coset_storage.storage.as_single_slice_mut();
         let l2_chunk_elems = get_l2_chunk_elems(domain_size)?;
         let mut num_cols_processed = 0;
+        let main_stream = get_stream();
+        let stream0 = CudaStream::create_with_flags(CudaStreamCreateFlags::NON_BLOCKING)?;
+        let stream1 = CudaStream::create_with_flags(CudaStreamCreateFlags::NON_BLOCKING)?;
+        set_l2_persistence_for_twiddles(&stream0)?;
+        set_l2_persistence_for_twiddles(&stream1)?;
+        let start_event = CudaEvent::create_with_flags(CudaEventCreateFlags::DISABLE_TIMING)?;
+        start_event.record(&main_stream)?;
+        stream0.wait_event(&start_event, CudaStreamWaitEventFlags::DEFAULT)?;
+        stream1.wait_event(&start_event, CudaStreamWaitEventFlags::DEFAULT)?;
         for (storage_chunk, coset_storage_chunk) in storage_slice
             .chunks(l2_chunk_elems)
             .zip(coset_storage_slice.chunks_mut(l2_chunk_elems))
         {
             let num_cols_this_chunk = storage_chunk.len() / domain_size;
-            ntt::batch_coset_ntt_into(
-                storage_chunk,
-                coset_storage_chunk,
-                coset_idx,
-                domain_size,
-                lde_degree,
-                num_cols_this_chunk,
-            )?;
+            let num_cols_stream0 = num_cols_this_chunk / 2;
+            let num_cols_stream1 = num_cols_this_chunk - num_cols_stream0;
+            let elems_stream0 = num_cols_stream0 * domain_size;
+            // ntt::batch_coset_ntt_into(
+            //     storage_chunk,
+            //     coset_storage_chunk,
+            //     coset_idx,
+            //     domain_size,
+            //     lde_degree,
+            //     num_cols_this_chunk,
+            // )?;
+            if num_cols_stream0 > 0 {
+                ntt::batch_coset_ntt_raw_into_with_stream(
+                    &storage_chunk[..elems_stream0],
+                    &mut coset_storage_chunk[..elems_stream0],
+                    false,
+                    false,
+                    coset_idx,
+                    domain_size,
+                    lde_degree,
+                    num_cols_stream0,
+                    &stream0,
+                )?;
+            }
+            if num_cols_stream1 > 0 {
+                ntt::batch_coset_ntt_raw_into_with_stream(
+                    &storage_chunk[elems_stream0..],
+                    &mut coset_storage_chunk[elems_stream0..],
+                    false,
+                    false,
+                    coset_idx,
+                    domain_size,
+                    lde_degree,
+                    num_cols_stream1,
+                    &stream1,
+                )?;
+            }
             num_cols_processed += num_cols_this_chunk;
         }
+        let end_event0 = CudaEvent::create_with_flags(CudaEventCreateFlags::DISABLE_TIMING)?;
+        let end_event1 = CudaEvent::create_with_flags(CudaEventCreateFlags::DISABLE_TIMING)?;
+        end_event0.record(&stream0)?;
+        end_event1.record(&stream1)?;
+        main_stream.wait_event(&end_event0, CudaStreamWaitEventFlags::DEFAULT)?;
+        main_stream.wait_event(&end_event1, CudaStreamWaitEventFlags::DEFAULT)?;
+
+        stream0.destroy()?;
+        stream1.destroy()?;
+        end_event0.destroy()?;
+        end_event1.destroy()?;
+
         assert_eq!(num_cols_processed, num_polys);
 
         Ok(())

--- a/src/data_structures/trace.rs
+++ b/src/data_structures/trace.rs
@@ -601,10 +601,8 @@ impl GenericTraceStorage<MonomialBasis> {
         // let l2_chunk_elems = 4 * domain_size; // get_l2_chunk_elems(domain_size)?;
         let mut num_cols_processed = 0;
         let main_stream = get_stream();
-        let stream0 = CudaStream::create_with_flags(CudaStreamCreateFlags::NON_BLOCKING)?;
-        let stream1 = CudaStream::create_with_flags(CudaStreamCreateFlags::NON_BLOCKING)?;
-        set_l2_persistence_for_twiddles(&stream0)?;
-        set_l2_persistence_for_twiddles(&stream1)?;
+        let stream0 = get_stream0();
+        let stream1 = get_stream1();
         let start_event = CudaEvent::create_with_flags(CudaEventCreateFlags::DISABLE_TIMING)?;
         start_event.record(&main_stream)?;
         stream0.wait_event(&start_event, CudaStreamWaitEventFlags::DEFAULT)?;
@@ -660,8 +658,6 @@ impl GenericTraceStorage<MonomialBasis> {
         main_stream.wait_event(&end_event0, CudaStreamWaitEventFlags::DEFAULT)?;
         main_stream.wait_event(&end_event1, CudaStreamWaitEventFlags::DEFAULT)?;
 
-        stream0.destroy()?;
-        stream1.destroy()?;
         end_event0.destroy()?;
         end_event1.destroy()?;
 

--- a/src/data_structures/trace.rs
+++ b/src/data_structures/trace.rs
@@ -8,6 +8,10 @@ use boojum::{
     field::U64Representable,
     worker::Worker,
 };
+
+use cudart::event::{CudaEvent, CudaEventCreateFlags};
+use cudart::stream::{CudaStream, CudaStreamCreateFlags, CudaStreamWaitEventFlags};
+
 use std::ops::Deref;
 use std::rc::Rc;
 
@@ -570,25 +574,97 @@ impl GenericTraceStorage<MonomialBasis> {
         let Self { storage, .. } = self;
         let domain_size = storage.domain_size;
 
+        // let storage_slice = storage.as_single_slice();
+        // let coset_storage_slice = coset_storage.storage.as_single_slice_mut();
+        // let l2_chunk_elems = get_l2_chunk_elems(domain_size)?;
+        // let mut num_cols_processed = 0;
+        // for (storage_chunk, coset_storage_chunk) in storage_slice
+        //     .chunks(l2_chunk_elems)
+        //     .zip(coset_storage_slice.chunks_mut(l2_chunk_elems))
+        // {
+        //     let num_cols_this_chunk = storage_chunk.len() / domain_size;
+        //     ntt::batch_coset_ntt_into(
+        //         storage_chunk,
+        //         coset_storage_chunk,
+        //         coset_idx,
+        //         domain_size,
+        //         lde_degree,
+        //         num_cols_this_chunk,
+        //     )?;
+        //     num_cols_processed += num_cols_this_chunk;
+        // }
+        // assert_eq!(num_cols_processed, num_polys);
+
         let storage_slice = storage.as_single_slice();
         let coset_storage_slice = coset_storage.storage.as_single_slice_mut();
         let l2_chunk_elems = get_l2_chunk_elems(domain_size)?;
+        // let l2_chunk_elems = 4 * domain_size; // get_l2_chunk_elems(domain_size)?;
         let mut num_cols_processed = 0;
+        let main_stream = get_stream();
+        let stream0 = CudaStream::create_with_flags(CudaStreamCreateFlags::NON_BLOCKING)?;
+        let stream1 = CudaStream::create_with_flags(CudaStreamCreateFlags::NON_BLOCKING)?;
+        set_l2_persistence_for_twiddles(&stream0)?;
+        set_l2_persistence_for_twiddles(&stream1)?;
+        let start_event = CudaEvent::create_with_flags(CudaEventCreateFlags::DISABLE_TIMING)?;
+        start_event.record(&main_stream)?;
+        stream0.wait_event(&start_event, CudaStreamWaitEventFlags::DEFAULT)?;
+        stream1.wait_event(&start_event, CudaStreamWaitEventFlags::DEFAULT)?;
         for (storage_chunk, coset_storage_chunk) in storage_slice
             .chunks(l2_chunk_elems)
             .zip(coset_storage_slice.chunks_mut(l2_chunk_elems))
         {
             let num_cols_this_chunk = storage_chunk.len() / domain_size;
-            ntt::batch_coset_ntt_into(
-                storage_chunk,
-                coset_storage_chunk,
-                coset_idx,
-                domain_size,
-                lde_degree,
-                num_cols_this_chunk,
-            )?;
+            let num_cols_stream0 = num_cols_this_chunk / 2;
+            let num_cols_stream1 = num_cols_this_chunk - num_cols_stream0;
+            let elems_stream0 = num_cols_stream0 * domain_size;
+            // ntt::batch_coset_ntt_into(
+            //     storage_chunk,
+            //     coset_storage_chunk,
+            //     coset_idx,
+            //     domain_size,
+            //     lde_degree,
+            //     num_cols_this_chunk,
+            // )?;
+            if num_cols_stream0 > 0 {
+              ntt::batch_coset_ntt_raw_into_with_stream(
+                  &storage_chunk[..elems_stream0],
+                  &mut coset_storage_chunk[..elems_stream0],
+                  false,
+                  false,
+                  coset_idx,
+                  domain_size,
+                  lde_degree,
+                  num_cols_stream0,
+                  &stream0,
+              )?;
+            }
+            if num_cols_stream1 > 0 {
+                ntt::batch_coset_ntt_raw_into_with_stream(
+                    &storage_chunk[elems_stream0..],
+                    &mut coset_storage_chunk[elems_stream0..],
+                    false,
+                    false,
+                    coset_idx,
+                    domain_size,
+                    lde_degree,
+                    num_cols_stream1,
+                    &stream1,
+                )?;
+            }
             num_cols_processed += num_cols_this_chunk;
         }
+        let end_event0 = CudaEvent::create_with_flags(CudaEventCreateFlags::DISABLE_TIMING)?;
+        let end_event1 = CudaEvent::create_with_flags(CudaEventCreateFlags::DISABLE_TIMING)?;
+        end_event0.record(&stream0)?;
+        end_event1.record(&stream1)?;
+        main_stream.wait_event(&end_event0, CudaStreamWaitEventFlags::DEFAULT)?;
+        main_stream.wait_event(&end_event1, CudaStreamWaitEventFlags::DEFAULT)?;
+
+        stream0.destroy()?;
+        stream1.destroy()?;
+        end_event0.destroy()?;
+        end_event1.destroy()?;
+
         assert_eq!(num_cols_processed, num_polys);
 
         Ok(())

--- a/src/test.rs
+++ b/src/test.rs
@@ -1167,26 +1167,26 @@ mod zksync {
             )
             .expect("gpu proof")
         };
-        println!("cpu proving");
-        let reference_proof = {
-            // we can't clone assembly lets synth it again
-            let proving_cs = synth_circuit_for_proving(circuit.clone(), &finalization_hint);
-            proving_cs
-                .prove_from_precomputations::<EXT, DefaultTranscript, DefaultTreeHasher, NoPow>(
-                    proof_cfg.clone(),
-                    &setup_base,
-                    &setup,
-                    &setup_tree,
-                    &vk,
-                    &vars_hint,
-                    &wits_hint,
-                    (),
-                    worker,
-                )
-        };
-        let actual_proof = gpu_proof.into();
-        circuit.verify_proof(&vk, &actual_proof);
-        compare_proofs(&reference_proof, &actual_proof);
+        // println!("cpu proving");
+        // let reference_proof = {
+        //     // we can't clone assembly lets synth it again
+        //     let proving_cs = synth_circuit_for_proving(circuit.clone(), &finalization_hint);
+        //     proving_cs
+        //         .prove_from_precomputations::<EXT, DefaultTranscript, DefaultTreeHasher, NoPow>(
+        //             proof_cfg.clone(),
+        //             &setup_base,
+        //             &setup,
+        //             &setup_tree,
+        //             &vk,
+        //             &vars_hint,
+        //             &wits_hint,
+        //             (),
+        //             worker,
+        //         )
+        // };
+        // let actual_proof = gpu_proof.into();
+        // circuit.verify_proof(&vk, &actual_proof);
+        // compare_proofs(&reference_proof, &actual_proof);
     }
 
     #[serial]


### PR DESCRIPTION
Superseded by https://github.com/matter-labs/era-shivini/pull/31. After @robik75 's big caching refactor, it was easier to start a new PR.

-------------------------

# What ❔

Batched NTT (+bitrev) operations launch a sequence of several kernels. This PR splits batches into chunks small enough to persist in the L2 cache across kernel launches, ie,  we do the whole NTT (+bitrev) sequence for the first chunk, then the second chunk, and so on.

## Why ❔

Leveraging L2 persistence this way reduces gmem traffic and improves performance.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and `cargo lint`.
