### PR TITLE
implement self-adjustable caching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# boojum = { path = "../era-boojum", package = "boojum" }
-# boojum-cuda = { path = "../era-boojum-cuda" }
-# cudart = { path = "../era-cuda/cudart", package = "cudart" }
-# circuit_definitions = { path = "../era-zkevm_test_harness/circuit_definitions", package = "circuit_definitions", optional = true }
-
 boojum = { git = "https://github.com/matter-labs/era-boojum", branch = "main" }
 boojum-cuda = { git = "https://github.com/matter-labs/era-boojum-cuda", branch = "main" }
 cudart = { git = "https://github.com/matter-labs/era-cuda", branch = "main", package = "cudart" }
+cudart-sys = { git = "https://github.com/matter-labs/era-cuda", branch = "main", package = "cudart-sys" }
 circuit_definitions = { git = "https://github.com/matter-labs/era-zkevm_test_harness", branch = "v1.4.1", package = "circuit_definitions", optional = true }
 
 rand = "0.8"
@@ -36,5 +32,7 @@ serial_test = "^2"
 [features]
 default = ["zksync"]
 zksync = ["circuit_definitions"]
-recompute = []
 allocator_stats = []
+
+[profile.release]
+incremental = true

--- a/src/constraint_evaluation.rs
+++ b/src/constraint_evaluation.rs
@@ -191,23 +191,18 @@ pub fn multi_polys_as_single_slice_mut<'a, P: PolyForm>(polys: &mut [Poly<'a, P>
 }
 
 // Accumulates into quotient
-pub fn generic_evaluate_constraints_by_coset<'a, 'b>(
-    trace_polys: &TracePolynomials<'a, CosetEvaluations>,
-    setup_polys: &SetupPolynomials<'a, CosetEvaluations>,
-    gates: &[cs_helpers::GateEvaluationParams],
+pub fn generic_evaluate_constraints_by_coset(
+    variable_cols: &[Poly<CosetEvaluations>],
+    witness_cols: &[Poly<CosetEvaluations>],
+    constant_cols: &[Poly<CosetEvaluations>],
+    gates: &[GateEvaluationParams],
     _selectors_placement: TreeNode,
     domain_size: usize,
     challenge: EF,
     challenge_power_offset: usize,
-    quotient: &mut ComplexPoly<'b, CosetEvaluations>,
-) -> CudaResult<()>
-where
-    'a: 'b,
-{
-    assert_eq!(
-        trace_polys.variable_cols[0].domain_size(),
-        quotient.domain_size()
-    );
+    quotient: &mut ComplexPoly<CosetEvaluations>,
+) -> CudaResult<()> {
+    assert_eq!(variable_cols[0].domain_size(), quotient.domain_size());
 
     let quotient_as_single_slice = unsafe {
         assert_eq!(
@@ -217,12 +212,6 @@ where
         let len = 2 * quotient.domain_size();
         std::slice::from_raw_parts_mut(quotient.c0.storage.as_mut().as_mut_ptr(), len)
     };
-    let TracePolynomials {
-        variable_cols,
-        witness_cols,
-        multiplicity_cols: _,
-    } = trace_polys;
-    let SetupPolynomials { constant_cols, .. } = setup_polys;
 
     let all_variable_cols = multi_polys_as_single_slice(&variable_cols);
     let all_witness_cols = multi_polys_as_single_slice(&witness_cols);

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,147 +1,104 @@
 use super::*;
+use boojum_cuda::context::Context;
+use std::collections::HashMap;
 
 pub struct ProverContext;
 
 pub const ZKSYNC_DEFAULT_TRACE_LOG_LENGTH: usize = 20;
 
 impl ProverContext {
-    pub fn create() -> CudaResult<Self> {
+    fn create_internal(
+        cuda_ctx: Context,
+        small_device_alloc: SmallStaticDeviceAllocator,
+        device_alloc: StaticDeviceAllocator,
+        small_host_alloc: SmallStaticHostAllocator,
+        host_alloc: StaticHostAllocator,
+    ) -> CudaResult<Self> {
         unsafe {
             assert!(_CUDA_CONTEXT.is_none());
+            _CUDA_CONTEXT = Some(cuda_ctx);
             assert!(_DEVICE_ALLOCATOR.is_none());
+            _DEVICE_ALLOCATOR = Some(device_alloc);
             assert!(_SMALL_DEVICE_ALLOCATOR.is_none());
+            _SMALL_DEVICE_ALLOCATOR = Some(small_device_alloc);
             assert!(_HOST_ALLOCATOR.is_none());
+            _HOST_ALLOCATOR = Some(host_alloc);
             assert!(_SMALL_HOST_ALLOCATOR.is_none());
+            _SMALL_HOST_ALLOCATOR = Some(small_host_alloc);
             assert!(_EXEC_STREAM.is_none());
+            _EXEC_STREAM = Some(Stream::create()?);
             assert!(_H2D_STREAM.is_none());
+            _H2D_STREAM = Some(Stream::create()?);
             assert!(_D2H_STREAM.is_none());
-        }
+            _D2H_STREAM = Some(Stream::create()?);
+            assert!(_SETUP_CACHE.is_none());
+            assert!(_STRATEGY_CACHE.is_none());
+            _STRATEGY_CACHE = Some(HashMap::new());
+        };
+        Ok(Self {})
+    }
+
+    pub fn create() -> CudaResult<Self> {
         // size counts in field elements
         let block_size = 1 << ZKSYNC_DEFAULT_TRACE_LOG_LENGTH;
         let cuda_ctx = CudaContext::create(12, 12)?;
-
         // grab small slice then consume everything
         let small_device_alloc = SmallStaticDeviceAllocator::init()?;
         let device_alloc = StaticDeviceAllocator::init_all(block_size)?;
-
         let small_host_alloc = SmallStaticHostAllocator::init()?;
         let host_alloc = StaticHostAllocator::init(1 << 8, block_size)?;
-
-        unsafe {
-            _CUDA_CONTEXT = Some(cuda_ctx);
-            _DEVICE_ALLOCATOR = Some(device_alloc);
-            _SMALL_DEVICE_ALLOCATOR = Some(small_device_alloc);
-            _HOST_ALLOCATOR = Some(host_alloc);
-            _SMALL_HOST_ALLOCATOR = Some(small_host_alloc);
-            _EXEC_STREAM = Some(Stream::create()?);
-            _H2D_STREAM = Some(Stream::create()?);
-            _D2H_STREAM = Some(Stream::create()?);
-        }
-
-        Ok(Self {})
+        Self::create_internal(
+            cuda_ctx,
+            small_device_alloc,
+            device_alloc,
+            small_host_alloc,
+            host_alloc,
+        )
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn create_limited_dev(block_size: usize) -> CudaResult<Self> {
-        unsafe {
-            assert!(_CUDA_CONTEXT.is_none());
-            assert!(_DEVICE_ALLOCATOR.is_none());
-            assert!(_SMALL_DEVICE_ALLOCATOR.is_none());
-            assert!(_HOST_ALLOCATOR.is_none());
-            assert!(_SMALL_HOST_ALLOCATOR.is_none());
-            assert!(_EXEC_STREAM.is_none());
-            assert!(_H2D_STREAM.is_none());
-            assert!(_D2H_STREAM.is_none());
-        }
-        // size counts in field elements
-        let cuda_ctx = CudaContext::create(12, 12)?;
-
-        // grab small slice then consume everything
-        let small_device_alloc = SmallStaticDeviceAllocator::init()?;
-        let device_alloc = StaticDeviceAllocator::init_limited(block_size)?;
-        let small_host_alloc = SmallStaticHostAllocator::init()?;
-        let host_alloc = StaticHostAllocator::init(1 << 8, block_size)?;
-
-        unsafe {
-            _CUDA_CONTEXT = Some(cuda_ctx);
-            _DEVICE_ALLOCATOR = Some(device_alloc);
-            _SMALL_DEVICE_ALLOCATOR = Some(small_device_alloc);
-            _HOST_ALLOCATOR = Some(host_alloc);
-            _SMALL_HOST_ALLOCATOR = Some(small_host_alloc);
-            _EXEC_STREAM = Some(Stream::create()?);
-            _H2D_STREAM = Some(Stream::create()?);
-            _D2H_STREAM = Some(Stream::create()?);
-        }
-
-        Ok(Self {})
-    }
-
-    pub fn create_limited() -> CudaResult<Self> {
-        unsafe {
-            assert!(_CUDA_CONTEXT.is_none());
-            assert!(_DEVICE_ALLOCATOR.is_none());
-            assert!(_SMALL_DEVICE_ALLOCATOR.is_none());
-            assert!(_HOST_ALLOCATOR.is_none());
-            assert!(_SMALL_HOST_ALLOCATOR.is_none());
-            assert!(_EXEC_STREAM.is_none());
-            assert!(_H2D_STREAM.is_none());
-            assert!(_D2H_STREAM.is_none());
-        }
+    pub fn create_limited(num_blocks: usize) -> CudaResult<Self> {
         // size counts in field elements
         let block_size = 1 << ZKSYNC_DEFAULT_TRACE_LOG_LENGTH;
         let cuda_ctx = CudaContext::create(12, 12)?;
-
         // grab small slice then consume everything
         let small_device_alloc = SmallStaticDeviceAllocator::init()?;
-        let device_alloc = StaticDeviceAllocator::init_limited(block_size)?;
+        let device_alloc = StaticDeviceAllocator::init(num_blocks, block_size)?;
         let small_host_alloc = SmallStaticHostAllocator::init()?;
         let host_alloc = StaticHostAllocator::init(1 << 8, block_size)?;
-
-        unsafe {
-            _CUDA_CONTEXT = Some(cuda_ctx);
-            _DEVICE_ALLOCATOR = Some(device_alloc);
-            _SMALL_DEVICE_ALLOCATOR = Some(small_device_alloc);
-            _HOST_ALLOCATOR = Some(host_alloc);
-            _SMALL_HOST_ALLOCATOR = Some(small_host_alloc);
-            _EXEC_STREAM = Some(Stream::create()?);
-            _H2D_STREAM = Some(Stream::create()?);
-            _D2H_STREAM = Some(Stream::create()?);
-        }
-
-        Ok(Self {})
+        Self::create_internal(
+            cuda_ctx,
+            small_device_alloc,
+            device_alloc,
+            small_host_alloc,
+            host_alloc,
+        )
     }
 
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn dev(domain_size: usize) -> CudaResult<Self> {
         assert!(domain_size.is_power_of_two());
         // size counts in field elements
         let block_size = domain_size;
         let cuda_ctx = CudaContext::create(12, 12)?;
-
         let small_device_alloc = SmallStaticDeviceAllocator::init()?;
         let device_alloc = StaticDeviceAllocator::init_all(block_size)?;
-
         let small_host_alloc = SmallStaticHostAllocator::init()?;
         let host_alloc = StaticHostAllocator::init(1 << 8, block_size)?;
-
-        unsafe {
-            _CUDA_CONTEXT = Some(cuda_ctx);
-            _DEVICE_ALLOCATOR = Some(device_alloc);
-            _SMALL_DEVICE_ALLOCATOR = Some(small_device_alloc);
-            _HOST_ALLOCATOR = Some(host_alloc);
-            _SMALL_HOST_ALLOCATOR = Some(small_host_alloc);
-            _EXEC_STREAM = Some(Stream::create()?);
-            _H2D_STREAM = Some(Stream::create()?);
-            _D2H_STREAM = Some(Stream::create()?);
-        }
-
-        Ok(Self {})
+        Self::create_internal(
+            cuda_ctx,
+            small_device_alloc,
+            device_alloc,
+            small_host_alloc,
+            host_alloc,
+        )
     }
 }
 
 impl Drop for ProverContext {
     fn drop(&mut self) {
         unsafe {
+            _setup_cache_reset();
+
             let cuda_ctx = _CUDA_CONTEXT.take().expect("cuda ctx");
             cuda_ctx.destroy().expect("destroy cuda ctx");
 
@@ -183,14 +140,16 @@ impl Drop for ProverContext {
                 .inner
                 .destroy()
                 .expect("destroy d2h stream");
+
+            drop(_STRATEGY_CACHE.take());
         }
     }
 }
 
-pub(crate) static mut _CUDA_CONTEXT: Option<CudaContext> = None;
-pub(crate) static mut _EXEC_STREAM: Option<Stream> = None;
-pub(crate) static mut _H2D_STREAM: Option<Stream> = None;
-pub(crate) static mut _D2H_STREAM: Option<Stream> = None;
+static mut _CUDA_CONTEXT: Option<CudaContext> = None;
+static mut _EXEC_STREAM: Option<Stream> = None;
+static mut _H2D_STREAM: Option<Stream> = None;
+static mut _D2H_STREAM: Option<Stream> = None;
 
 pub(crate) fn get_stream() -> &'static CudaStream {
     unsafe { &_EXEC_STREAM.as_ref().expect("execution stream").inner }
@@ -207,11 +166,11 @@ pub(crate) fn get_d2h_stream() -> &'static CudaStream {
 }
 
 pub fn synchronize_streams() -> CudaResult<()> {
-    get_stream().synchronize()?;
-    get_h2d_stream().synchronize()?;
-    get_d2h_stream().synchronize()?;
-
-    Ok(())
+    if_not_dry_run! {
+        get_stream().synchronize()?;
+        get_h2d_stream().synchronize()?;
+        get_d2h_stream().synchronize()
+    }
 }
 
 // use custom wrapper to work around send + sync requirement of static var
@@ -230,14 +189,14 @@ impl Stream {
 unsafe impl Send for Stream {}
 unsafe impl Sync for Stream {}
 
-pub(crate) static mut _DEVICE_ALLOCATOR: Option<StaticDeviceAllocator> = None;
-pub(crate) static mut _SMALL_DEVICE_ALLOCATOR: Option<SmallStaticDeviceAllocator> = None;
-pub(crate) static mut _HOST_ALLOCATOR: Option<StaticHostAllocator> = None;
-pub(crate) static mut _SMALL_HOST_ALLOCATOR: Option<SmallStaticHostAllocator> = None;
+static mut _DEVICE_ALLOCATOR: Option<StaticDeviceAllocator> = None;
+static mut _SMALL_DEVICE_ALLOCATOR: Option<SmallStaticDeviceAllocator> = None;
+static mut _HOST_ALLOCATOR: Option<StaticHostAllocator> = None;
+static mut _SMALL_HOST_ALLOCATOR: Option<SmallStaticHostAllocator> = None;
 
 pub(crate) fn _alloc() -> &'static StaticDeviceAllocator {
     unsafe {
-        &_DEVICE_ALLOCATOR
+        _DEVICE_ALLOCATOR
             .as_ref()
             .expect("device allocator should be initialized")
     }
@@ -245,14 +204,14 @@ pub(crate) fn _alloc() -> &'static StaticDeviceAllocator {
 
 pub(crate) fn _small_alloc() -> &'static SmallStaticDeviceAllocator {
     unsafe {
-        &_SMALL_DEVICE_ALLOCATOR
+        _SMALL_DEVICE_ALLOCATOR
             .as_ref()
             .expect("small device allocator should be initialized")
     }
 }
 pub(crate) fn _host_alloc() -> &'static StaticHostAllocator {
     unsafe {
-        &_HOST_ALLOCATOR
+        _HOST_ALLOCATOR
             .as_ref()
             .expect("host allocator should be initialized")
     }
@@ -260,8 +219,52 @@ pub(crate) fn _host_alloc() -> &'static StaticHostAllocator {
 
 pub(crate) fn _small_host_alloc() -> &'static SmallStaticHostAllocator {
     unsafe {
-        &_SMALL_HOST_ALLOCATOR
+        _SMALL_HOST_ALLOCATOR
             .as_ref()
             .expect("small host allocator should be initialized")
+    }
+}
+
+static mut _SETUP_CACHE: Option<SetupCache> = None;
+
+pub(crate) fn _setup_cache_get() -> Option<&'static mut SetupCache> {
+    unsafe { _SETUP_CACHE.as_mut() }
+}
+
+pub(crate) fn _setup_cache_set(value: SetupCache) {
+    unsafe {
+        assert!(_SETUP_CACHE.is_none());
+        _SETUP_CACHE = Some(value)
+    }
+}
+
+pub(crate) fn _setup_cache_reset() {
+    unsafe { _SETUP_CACHE = None }
+}
+
+static mut _STRATEGY_CACHE: Option<HashMap<Vec<[F; 4]>, CacheStrategy>> = None;
+
+pub(crate) fn _strategy_cache_get() -> &'static mut HashMap<Vec<[F; 4]>, CacheStrategy> {
+    unsafe {
+        _STRATEGY_CACHE
+            .as_mut()
+            .expect("strategy cache should be initialized")
+    }
+}
+pub(crate) fn _strategy_cache_reset() {
+    unsafe { _STRATEGY_CACHE = Some(HashMap::new()) }
+}
+
+pub(crate) fn is_prover_context_initialized() -> bool {
+    unsafe {
+        _CUDA_CONTEXT.is_some()
+            & _EXEC_STREAM.is_some()
+            & _H2D_STREAM.is_some()
+            & _D2H_STREAM.is_some()
+            & _DEVICE_ALLOCATOR.is_some()
+            & _SMALL_DEVICE_ALLOCATOR.is_some()
+            & _HOST_ALLOCATOR.is_some()
+            & _SMALL_HOST_ALLOCATOR.is_some()
+            & _STRATEGY_CACHE.is_some()
     }
 }

--- a/src/cs/witness.rs
+++ b/src/cs/witness.rs
@@ -12,17 +12,7 @@ pub fn variable_assignment(
         return Ok(());
     }
     assert!(d_variable_values.len() > 0);
-    assert!(d_variable_indexes.len() <= d_result.len());
-    assert_eq!(
-        d_variable_indexes.len() as u32 & PACKED_PLACEHOLDER_BITMASK,
-        0
-    );
-
-    let (d_result, padding) = d_result.split_at_mut(d_variable_indexes.len());
-    if !padding.is_empty() {
-        helpers::set_zero(padding)?;
-    }
-
+    assert_eq!(d_variable_indexes.len(), d_result.len());
     let (d_variable_indexes_ref, d_variable_values_ref, d_result) = unsafe {
         (
             DeviceSlice::from_slice(&d_variable_indexes),
@@ -30,13 +20,12 @@ pub fn variable_assignment(
             DeviceSlice::from_mut_slice(d_result),
         )
     };
-
-    select(
-        d_variable_indexes_ref,
-        d_variable_values_ref,
-        d_result,
-        get_stream(),
-    )?;
-
-    Ok(())
+    if_not_dry_run! {
+        select(
+            d_variable_indexes_ref,
+            d_variable_values_ref,
+            d_result,
+            get_stream(),
+        )
+    }
 }

--- a/src/data_structures/arguments.rs
+++ b/src/data_structures/arguments.rs
@@ -1,32 +1,22 @@
+use crate::data_structures::cache::StorageCache;
 use boojum::cs::{implementations::proof::OracleQuery, oracle::TreeHasher, LookupParameters};
-use std::ops::Deref;
+use std::ops::{Deref, Range};
 use std::rc::Rc;
 
 use super::*;
 
-pub struct GenericArgumentStorage<'a, P: PolyForm> {
-    pub storage: GenericComplexPolynomialStorage<'a, P>,
-    pub coset_idx: Option<usize>,
-    pub layout: ArgumentsLayout,
-    form: std::marker::PhantomData<P>,
+#[allow(dead_code)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ArgumentsPolyType {
+    Z,
+    PartialProduct,
+    LookupA,
+    LookupB,
 }
 
-pub struct ArgumentPolynomials<'a, P: PolyForm> {
-    pub z_poly: &'a ComplexPoly<'a, P>,
-    pub partial_products: &'a [ComplexPoly<'a, P>],
-    pub lookup_a_polys: &'a [ComplexPoly<'a, P>],
-    pub lookup_b_polys: &'a [ComplexPoly<'a, P>],
-}
-
-pub struct ArgumentPolynomialsMut<'a, P: PolyForm> {
-    pub z_poly: &'a mut ComplexPoly<'a, P>,
-    pub partial_products: &'a mut [ComplexPoly<'a, P>],
-    pub lookup_a_polys: &'a mut [ComplexPoly<'a, P>],
-    pub lookup_b_polys: &'a mut [ComplexPoly<'a, P>],
-}
-
-#[derive(Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct ArgumentsLayout {
+    pub num_z_polys: usize,
     pub num_partial_products: usize,
     pub num_lookup_a_polys: usize,
     pub num_lookup_b_polys: usize,
@@ -38,12 +28,8 @@ impl ArgumentsLayout {
         quotient_degree: usize,
         lookup_params: LookupParameters,
     ) -> Self {
-        let TraceLayout {
-            num_variable_cols,
-            num_witness_cols: _,
-            num_multiplicity_cols: _,
-        } = trace_layout;
-
+        let num_z_polys = 1;
+        let num_variable_cols = trace_layout.num_variable_cols;
         let mut num_partial_products = num_variable_cols / quotient_degree;
         if num_variable_cols % quotient_degree != 0 {
             num_partial_products += 1;
@@ -60,7 +46,7 @@ impl ArgumentsLayout {
                         num_repetitions,
                         share_table_id,
                     } => {
-                        assert!(share_table_id == false);
+                        assert!(!share_table_id);
                         (num_repetitions, 1)
                     }
                     LookupParameters::UseSpecializedColumnsWithTableIdAsConstant {
@@ -69,14 +55,19 @@ impl ArgumentsLayout {
                         share_table_id,
                     } => {
                         assert!(share_table_id);
-
                         (num_repetitions, 1)
                     }
                     _ => unreachable!(),
                 }
             };
 
+        let num_z_polys = num_z_polys * 2;
+        let num_partial_products = num_partial_products * 2;
+        let num_lookup_a_polys = num_lookup_a_polys * 2;
+        let num_lookup_b_polys = num_lookup_b_polys * 2;
+
         Self {
+            num_z_polys,
             num_partial_products,
             num_lookup_a_polys,
             num_lookup_b_polys,
@@ -84,182 +75,123 @@ impl ArgumentsLayout {
     }
 
     pub fn num_polys(&self) -> usize {
-        1 + self.num_partial_products + self.num_lookup_a_polys + self.num_lookup_b_polys
+        self.num_z_polys
+            + self.num_partial_products
+            + self.num_lookup_a_polys
+            + self.num_lookup_b_polys
     }
 }
 
-impl<'a, P: PolyForm> GenericArgumentStorage<'a, P> {
-    pub fn num_polys(&self) -> usize {
-        self.layout.num_polys()
+impl GenericStorageLayout for ArgumentsLayout {
+    type PolyType = ArgumentsPolyType;
+
+    fn num_polys(&self) -> usize {
+        self.num_polys()
     }
 
-    pub fn domain_size(&self) -> usize {
-        self.storage.polynomials[0].c0.storage.len()
+    fn poly_range(&self, poly_type: Self::PolyType) -> (Range<usize>, Self) {
+        let start = match poly_type {
+            ArgumentsPolyType::Z => 0,
+            ArgumentsPolyType::PartialProduct => self.num_z_polys,
+            ArgumentsPolyType::LookupA => self.num_z_polys + self.num_partial_products,
+            ArgumentsPolyType::LookupB => {
+                self.num_z_polys + self.num_partial_products + self.num_lookup_a_polys
+            }
+        };
+        let len = match poly_type {
+            ArgumentsPolyType::Z => self.num_z_polys,
+            ArgumentsPolyType::PartialProduct => self.num_partial_products,
+            ArgumentsPolyType::LookupA => self.num_lookup_a_polys,
+            ArgumentsPolyType::LookupB => self.num_lookup_b_polys,
+        };
+        let range = start..start + len;
+        let layout = Self {
+            num_z_polys: match poly_type {
+                ArgumentsPolyType::Z => self.num_z_polys,
+                _ => 0,
+            },
+            num_partial_products: match poly_type {
+                ArgumentsPolyType::PartialProduct => self.num_partial_products,
+                _ => 0,
+            },
+            num_lookup_a_polys: match poly_type {
+                ArgumentsPolyType::LookupA => self.num_lookup_a_polys,
+                _ => 0,
+            },
+            num_lookup_b_polys: match poly_type {
+                ArgumentsPolyType::LookupB => self.num_lookup_b_polys,
+                _ => 0,
+            },
+        };
+        (range, layout)
     }
+}
 
-    pub fn allocate(layout: ArgumentsLayout, domain_size: usize) -> CudaResult<Self> {
-        let storage = GenericComplexPolynomialStorage::allocate(layout.num_polys(), domain_size)?;
+pub type GenericArgumentsStorage<P> = GenericStorage<P, ArgumentsLayout>;
 
-        Ok(Self {
-            storage,
-            layout,
-            coset_idx: None,
-            form: std::marker::PhantomData,
-        })
-    }
+pub type ArgumentsCache = StorageCache<ArgumentsLayout, ()>;
 
-    pub fn split_into_arguments(&self) -> (&[ComplexPoly<P>], &[ComplexPoly<P>]) {
-        let num_copy_permutation_polys = 1 + self.layout.num_partial_products;
-        self.storage
-            .polynomials
-            .split_at(num_copy_permutation_polys)
-    }
+pub struct ArgumentsPolynomials<'a, P: PolyForm> {
+    pub z_polys: Vec<ComplexPoly<'a, P>>,
+    pub partial_products: Vec<ComplexPoly<'a, P>>,
+    pub lookup_a_polys: Vec<ComplexPoly<'a, P>>,
+    pub lookup_b_polys: Vec<ComplexPoly<'a, P>>,
+}
 
-    pub fn as_polynomials(&'a self) -> ArgumentPolynomials<'a, P> {
-        let (copy_permutation_polys, lookup_polys) = self.split_into_arguments();
-        let (lookup_a_polys, lookup_b_polys) =
-            lookup_polys.split_at(self.layout.num_lookup_a_polys);
-
-        ArgumentPolynomials {
-            z_poly: &copy_permutation_polys[0],
-            partial_products: &copy_permutation_polys[1..],
+impl<'a, P: PolyForm> ArgumentsPolynomials<'a, P> {
+    pub fn new(mut polynomials: Vec<ComplexPoly<'a, P>>, layout: ArgumentsLayout) -> Self {
+        let ArgumentsLayout {
+            num_z_polys,
+            num_partial_products,
+            num_lookup_a_polys,
+            num_lookup_b_polys,
+        } = layout;
+        assert_eq!(num_z_polys % 2, 0);
+        let num_z_polys = num_z_polys / 2;
+        assert_eq!(num_partial_products % 2, 0);
+        let num_partial_products = num_partial_products / 2;
+        assert_eq!(num_lookup_a_polys % 2, 0);
+        let num_lookup_a_polys = num_lookup_a_polys / 2;
+        assert_eq!(num_lookup_b_polys % 2, 0);
+        let num_lookup_b_polys = num_lookup_b_polys / 2;
+        let lookup_b_polys = polynomials.split_off(polynomials.len() - num_lookup_b_polys);
+        let lookup_a_polys = polynomials.split_off(polynomials.len() - num_lookup_a_polys);
+        let partial_products = polynomials.split_off(polynomials.len() - num_partial_products);
+        let z_polys = polynomials.split_off(polynomials.len() - num_z_polys);
+        assert!(polynomials.is_empty());
+        Self {
+            z_polys,
+            partial_products,
             lookup_a_polys,
             lookup_b_polys,
         }
     }
+}
 
-    pub fn as_polynomials_mut(&self) -> ArgumentPolynomialsMut<P> {
-        unsafe { std::mem::transmute(self.as_polynomials()) }
+impl<P: PolyForm> GenericArgumentsStorage<P> {
+    pub fn as_polynomials(&self) -> ArgumentsPolynomials<P> {
+        let layout = self.layout;
+        let polynomials = self.as_complex_polys();
+        ArgumentsPolynomials::new(polynomials, layout)
     }
 
-    #[allow(dead_code)]
-    pub fn clone(&self) -> CudaResult<Self> {
-        let _num_polys = self.num_polys();
-        let _domain_size = self.domain_size();
-
-        let new = self.storage.clone()?;
-
-        Ok(Self {
-            storage: new,
-            coset_idx: self.coset_idx.clone(),
-            layout: self.layout.clone(),
-            form: std::marker::PhantomData,
-        })
+    pub fn as_polynomials_mut(&mut self) -> ArgumentsPolynomials<P> {
+        let layout = self.layout;
+        let polynomials = self.as_complex_polys_mut();
+        ArgumentsPolynomials::new(polynomials, layout)
     }
 }
 
-impl<'a> GenericArgumentStorage<'a, LagrangeBasis> {
-    pub fn into_monomial(self) -> CudaResult<GenericArgumentStorage<'static, MonomialBasis>> {
-        let num_polys = self.num_polys();
-        let domain_size = self.domain_size();
-
-        let Self {
-            mut storage,
-            layout,
-            ..
-        } = self;
-        let num_ntts = 2 * num_polys;
-        ntt::batch_ntt(
-            storage.as_single_slice_mut(),
-            false,
-            true,
-            domain_size,
-            num_ntts,
-        )?;
-
-        ntt::batch_bitreverse(storage.as_single_slice_mut(), domain_size)?;
-
-        let monomial_storage = unsafe { std::mem::transmute(storage) };
-
-        Ok(GenericArgumentStorage {
-            storage: monomial_storage,
-            coset_idx: None,
-            layout,
-            form: std::marker::PhantomData,
-        })
-    }
-}
-
-impl<'a> GenericArgumentStorage<'a, MonomialBasis> {
-    pub fn into_coset_eval<'b>(
-        &self,
-        coset_idx: usize,
-        lde_degree: usize,
-        coset_storage: &mut GenericArgumentStorage<'b, CosetEvaluations>,
-    ) -> CudaResult<()> {
-        let num_polys = self.num_polys();
-        let domain_size = self.domain_size();
-
-        let num_coset_ffts = 2 * num_polys;
-        ntt::batch_coset_ntt_into(
-            self.storage.as_single_slice(),
-            coset_storage.storage.as_single_slice_mut(),
-            coset_idx,
-            domain_size,
-            lde_degree,
-            num_coset_ffts,
-        )?;
-
-        Ok(())
-    }
-}
-
-impl<'a> GenericArgumentStorage<'a, CosetEvaluations> {
-    pub fn build_subtree_for_coset(
-        &self,
-        cap_size: usize,
-        coset_idx: usize,
-    ) -> CudaResult<(SubTree, Vec<[F; 4]>)> {
-        let domain_size = self.domain_size();
-        let Self { storage, .. } = self;
-        let leaf_sources = storage.as_single_slice();
-        let mut subtree = dvec!(2 * NUM_EL_PER_HASH * domain_size);
-        let subtree_root = compute_tree_cap(leaf_sources, &mut subtree, domain_size, cap_size, 1)?;
-
-        let subtree = SubTree::new(subtree, domain_size, cap_size, coset_idx);
-        Ok((subtree, subtree_root))
-    }
-
+impl GenericArgumentsStorage<CosetEvaluations> {
     pub(crate) fn barycentric_evaluate(
         &self,
         bases: &PrecomputedBasisForBarycentric,
     ) -> CudaResult<Vec<EF>> {
-        batch_barycentric_evaluate_ext(&self.storage, bases, self.domain_size(), self.num_polys())
+        batch_barycentric_evaluate_ext(self, bases, self.domain_size(), self.num_polys() / 2)
     }
 }
 
-impl<'a> AsSingleSlice for GenericArgumentStorage<'a, CosetEvaluations> {
-    fn domain_size(&self) -> usize {
-        self.storage.domain_size()
-    }
-
-    fn num_polys(&self) -> usize {
-        self.storage.polynomials.len()
-    }
-
-    fn as_single_slice(&self) -> &[F] {
-        self.storage.as_single_slice()
-    }
-
-    fn as_single_slice_mut(&mut self) -> &mut [F] {
-        self.storage.as_single_slice_mut()
-    }
-}
-
-impl<'a> AsSingleSlice for &GenericArgumentStorage<'a, CosetEvaluations> {
-    fn domain_size(&self) -> usize {
-        self.storage.domain_size()
-    }
-
-    fn num_polys(&self) -> usize {
-        self.storage.polynomials.len()
-    }
-
-    fn as_single_slice(&self) -> &[F] {
-        self.storage.as_single_slice()
-    }
-}
-impl<'a> LeafSourceQuery for ArgumentPolynomials<'a, CosetEvaluations> {
+impl<'a> LeafSourceQuery for ArgumentsPolynomials<'a, CosetEvaluations> {
     fn get_leaf_sources(
         &self,
         _coset_idx: usize,
@@ -269,11 +201,12 @@ impl<'a> LeafSourceQuery for ArgumentPolynomials<'a, CosetEvaluations> {
         _: usize,
     ) -> CudaResult<Vec<F>> {
         let _leaf_sources: Vec<F> = vec![];
-
         let mut values = vec![];
-        let el = self.z_poly.c0.storage.clone_el_to_host(row_idx)?;
+        assert_eq!(self.z_polys.len(), 1);
+        let z_poly = &self.z_polys[0];
+        let el = z_poly.c0.storage.clone_el_to_host(row_idx)?;
         values.push(el);
-        let el = self.z_poly.c1.storage.clone_el_to_host(row_idx)?;
+        let el = z_poly.c1.storage.clone_el_to_host(row_idx)?;
         values.push(el);
 
         for p in self.partial_products.iter() {
@@ -300,152 +233,6 @@ impl<'a> LeafSourceQuery for ArgumentPolynomials<'a, CosetEvaluations> {
         }
 
         Ok(values)
-    }
-}
-
-pub struct ArgumentCache<'a> {
-    monomials: GenericArgumentStorage<'a, MonomialBasis>,
-    cosets: Vec<Option<Rc<GenericArgumentStorage<'a, CosetEvaluations>>>>,
-    fri_lde_degree: usize,
-    used_lde_degree: usize,
-}
-
-impl<'a> ArgumentCache<'a> {
-    pub fn from_monomial(
-        monomials: GenericArgumentStorage<'a, MonomialBasis>,
-        fri_lde_degree: usize,
-        used_lde_degree: usize,
-    ) -> CudaResult<Self> {
-        assert!(fri_lde_degree.is_power_of_two());
-        assert!(used_lde_degree.is_power_of_two());
-
-        let cosets = vec![None; fri_lde_degree];
-
-        Ok(Self {
-            monomials,
-            cosets,
-            fri_lde_degree,
-            used_lde_degree,
-        })
-    }
-
-    pub fn num_polys(&self) -> usize {
-        self.monomials.num_polys()
-    }
-    pub fn num_polys_in_base(&self) -> usize {
-        2 * self.monomials.num_polys()
-    }
-
-    pub fn commit<H: TreeHasher<F, Output = [F; 4]>>(
-        &mut self,
-        cap_size: usize,
-    ) -> CudaResult<(Vec<SubTree>, Vec<[F; 4]>)> {
-        let fri_lde_degree = self.fri_lde_degree;
-        let _used_lde_degree = self.used_lde_degree;
-        let coset_cap_size = coset_cap_size(cap_size, self.fri_lde_degree);
-        let mut setup_subtrees = vec![];
-        let mut setup_subtree_caps = vec![];
-
-        assert_eq!(self.cosets.len(), fri_lde_degree);
-
-        for coset_idx in 0..fri_lde_degree {
-            let coset_values = self.get_or_compute_coset_evals(coset_idx)?;
-            let (subtree, subtree_cap) =
-                coset_values.build_subtree_for_coset(coset_cap_size, coset_idx)?;
-            setup_subtree_caps.push(subtree_cap);
-            setup_subtrees.push(subtree);
-        }
-
-        let setup_tree_cap = setup_subtree_caps.compute_cap::<H>(&mut setup_subtrees, cap_size)?;
-
-        Ok((setup_subtrees, setup_tree_cap))
-    }
-
-    pub fn get_or_compute_coset_evals(
-        &mut self,
-        coset_idx: usize,
-    ) -> CudaResult<Rc<GenericArgumentStorage<CosetEvaluations>>> {
-        assert!(coset_idx < self.used_lde_degree);
-
-        if REMEMBER_COSETS == false || coset_idx >= self.fri_lde_degree {
-            let mut tmp_coset = GenericArgumentStorage::allocate(
-                self.monomials.layout.clone(),
-                self.monomials.domain_size(),
-            )?;
-            self.monomials
-                .into_coset_eval(coset_idx, self.used_lde_degree, &mut tmp_coset)?;
-            return Ok(Rc::new(tmp_coset));
-        }
-
-        if self.cosets[coset_idx].is_none() {
-            let mut current_storage = GenericArgumentStorage::allocate(
-                self.monomials.layout.clone(),
-                self.monomials.domain_size(),
-            )?;
-            self.monomials.into_coset_eval(
-                coset_idx,
-                self.used_lde_degree,
-                &mut current_storage,
-            )?;
-            self.cosets[coset_idx] = Some(Rc::new(current_storage));
-        }
-
-        return Ok(self.cosets[coset_idx].as_ref().unwrap().clone());
-    }
-
-    #[allow(dead_code)]
-    pub fn query<H: TreeHasher<F, Output = [F; 4]>>(
-        &mut self,
-        coset_idx: usize,
-        fri_lde_degree: usize,
-        row_idx: usize,
-        domain_size: usize,
-        tree_holder: &TreeCache,
-    ) -> CudaResult<OracleQuery<F, H>> {
-        let leaf_sources = self.get_or_compute_coset_evals(coset_idx)?;
-        tree_holder.get_argument_subtrees().query(
-            &leaf_sources.as_polynomials(),
-            coset_idx,
-            fri_lde_degree,
-            row_idx,
-            domain_size,
-        )
-    }
-
-    pub fn batch_query_for_coset<H: TreeHasher<F, Output = [F; 4]>, A: GoodAllocator>(
-        &mut self,
-        coset_idx: usize,
-        indexes: &DVec<u32, SmallStaticDeviceAllocator>,
-        num_queries: usize,
-        domain_size: usize,
-        h_all_leaf_elems: &mut Vec<F, A>,
-        h_all_proofs: &mut Vec<F, A>,
-        tree_holder: &TreeCache,
-    ) -> CudaResult<()> {
-        let num_polys = self.num_polys_in_base();
-        let leaf_sources = self.get_or_compute_coset_evals(coset_idx)?;
-        let oracle_data = tree_holder.get_argument_subtree(coset_idx);
-        batch_query::<H, A>(
-            indexes,
-            num_queries,
-            leaf_sources.deref(),
-            num_polys,
-            oracle_data,
-            oracle_data.cap_size,
-            domain_size,
-            1,
-            h_all_leaf_elems,
-            h_all_proofs,
-        )
-    }
-
-    pub fn get_z_monomial(&'a self) -> &ComplexPoly<'a, MonomialBasis> {
-        self.monomials.as_polynomials().z_poly
-    }
-
-    #[allow(dead_code)]
-    pub fn layout(&self) -> ArgumentsLayout {
-        self.monomials.layout.clone()
     }
 }
 
@@ -514,7 +301,7 @@ impl<'a> QuotientCache<'a> {
     ) -> CudaResult<Rc<GenericComplexPolynomialStorage<'a, CosetEvaluations>>> {
         assert!(coset_idx < self.used_lde_degree);
 
-        if REMEMBER_COSETS == false || coset_idx >= self.fri_lde_degree {
+        if coset_idx >= self.fri_lde_degree {
             let mut tmp_coset = GenericComplexPolynomialStorage::allocate(
                 self.monomials.num_polys(),
                 self.monomials.domain_size(),

--- a/src/data_structures/cache.rs
+++ b/src/data_structures/cache.rs
@@ -1,0 +1,680 @@
+use boojum::config::ProvingCSConfig;
+use boojum::cs::implementations::pow::PoWRunner;
+use boojum::cs::implementations::prover::ProofConfig;
+use boojum::cs::implementations::reference_cs::CSReferenceAssembly;
+use boojum::cs::implementations::transcript::Transcript;
+use boojum::cs::implementations::verifier::VerificationKey;
+use boojum::cs::implementations::witness::WitnessVec;
+use boojum::cs::oracle::TreeHasher;
+use boojum::field::traits::field_like::PrimeFieldLikeVectorized;
+use boojum::worker::Worker;
+use cudart_sys::CudaError::ErrorMemoryAllocation;
+use std::collections::BTreeMap;
+use std::ops::Deref;
+use std::rc::Rc;
+
+use crate::data_structures::{GenericStorage, GenericStorageLayout};
+use crate::oracle::SubTree;
+use crate::poly::{CosetEvaluations, LagrangeBasis, MonomialBasis};
+
+use super::*;
+
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub enum StorageCacheStrategy {
+    InPlace,
+    CacheMonomials,
+    CacheMonomialsAndFirstCoset,
+    CacheMonomialsAndFriCosets,
+    CacheEvaluationsAndMonomials,
+    CacheEvaluationsMonomialsAndFirstCoset,
+    CacheEvaluationsMonomialsAndFriCosets,
+    CacheEvaluationsAndAllCosets,
+}
+
+impl StorageCacheStrategy {
+    pub fn required_storages_count(&self, fri_lde_degree: usize, used_lde_degree: usize) -> usize {
+        match self {
+            InPlace => 1,
+            CacheMonomials => 1,
+            CacheMonomialsAndFirstCoset => 2,
+            CacheMonomialsAndFriCosets => 1 + fri_lde_degree,
+            CacheEvaluationsAndMonomials => 2,
+            CacheEvaluationsMonomialsAndFirstCoset => 3,
+            CacheEvaluationsMonomialsAndFriCosets => 2 + fri_lde_degree,
+            CacheEvaluationsAndAllCosets => 1 + used_lde_degree,
+        }
+    }
+}
+
+use crate::cs::GpuSetup;
+use crate::prover::{
+    compute_quotient_degree, gpu_prove_from_external_witness_data_with_cache_strategy,
+};
+use StorageCacheStrategy::*;
+
+pub struct StorageCache<L: GenericStorageLayout, T> {
+    pub strategy: StorageCacheStrategy,
+    pub layout: L,
+    pub domain_size: usize,
+    pub fri_lde_degree: usize,
+    pub used_lde_degree: usize,
+    pub cap_size: usize,
+    pub aux: T,
+    evaluations: Option<Rc<GenericStorage<LagrangeBasis, L>>>,
+    monomials: Option<Rc<GenericStorage<MonomialBasis, L>>>,
+    coset_evaluations: BTreeMap<usize, Rc<GenericStorage<CosetEvaluations, L>>>,
+    subtrees_and_caps: BTreeMap<usize, (SubTree, Vec<[F; 4]>)>,
+    uninitialized_storages: Vec<GenericStorage<Undefined, L>>,
+    uninitialized_subtree_nodes: Vec<DVec<F>>,
+}
+
+impl<L: GenericStorageLayout, T> StorageCache<L, T> {
+    fn required_storages_count(&self) -> usize {
+        self.strategy
+            .required_storages_count(self.fri_lde_degree, self.used_lde_degree)
+    }
+
+    fn allocate(
+        strategy: StorageCacheStrategy,
+        layout: L,
+        domain_size: usize,
+        fri_lde_degree: usize,
+        used_lde_degree: usize,
+        cap_size: usize,
+        aux: T,
+        will_own_evaluations: bool,
+    ) -> Self {
+        let mut storages_count = strategy.required_storages_count(fri_lde_degree, used_lde_degree);
+        if will_own_evaluations {
+            storages_count -= 1;
+        }
+        let unused_storages = (0..storages_count)
+            .map(|_| GenericStorage::allocate(layout, domain_size))
+            .collect();
+        let nodes_size = 2 * NUM_EL_PER_HASH * domain_size;
+        let unused_subtree_nodes = (0..fri_lde_degree).map(|_| dvec!(nodes_size)).collect();
+        Self {
+            strategy,
+            layout,
+            domain_size,
+            fri_lde_degree,
+            used_lde_degree,
+            cap_size,
+            aux,
+            evaluations: None,
+            monomials: None,
+            coset_evaluations: BTreeMap::new(),
+            subtrees_and_caps: BTreeMap::new(),
+            uninitialized_storages: unused_storages,
+            uninitialized_subtree_nodes: unused_subtree_nodes,
+        }
+    }
+
+    pub fn new(
+        strategy: StorageCacheStrategy,
+        layout: L,
+        domain_size: usize,
+        fri_lde_degree: usize,
+        used_lde_degree: usize,
+        cap_size: usize,
+        aux: T,
+    ) -> Self {
+        Self::allocate(
+            strategy,
+            layout,
+            domain_size,
+            fri_lde_degree,
+            used_lde_degree,
+            cap_size,
+            aux,
+            false,
+        )
+    }
+
+    pub fn new_and_initialize(
+        strategy: StorageCacheStrategy,
+        layout: L,
+        domain_size: usize,
+        fri_lde_degree: usize,
+        used_lde_degree: usize,
+        cap_size: usize,
+        aux: T,
+        evaluations: GenericStorage<LagrangeBasis, L>,
+    ) -> CudaResult<Self> {
+        let mut cache = Self::allocate(
+            strategy,
+            layout,
+            domain_size,
+            fri_lde_degree,
+            used_lde_degree,
+            cap_size,
+            aux,
+            true,
+        );
+        cache.initialize(Rc::new(evaluations))?;
+        Ok(cache)
+    }
+
+    fn pop_storage(&mut self) -> GenericStorage<Undefined, L> {
+        self.uninitialized_storages.pop().unwrap()
+    }
+
+    pub fn get_temp_storage(&self) -> GenericStorage<Undefined, L> {
+        GenericStorage::allocate(self.layout, self.domain_size)
+    }
+
+    pub fn get_evaluations_storage(&mut self) -> GenericStorage<Undefined, L> {
+        assert_eq!(
+            self.uninitialized_storages.len(),
+            self.required_storages_count()
+        );
+        self.pop_storage()
+    }
+
+    pub fn initialize(
+        &mut self,
+        evaluations: Rc<GenericStorage<LagrangeBasis, L>>,
+    ) -> CudaResult<()> {
+        let can_owns_evaluations = Rc::strong_count(&evaluations) == 1;
+        let must_own_evaluations = match self.strategy {
+            InPlace | CacheMonomials | CacheMonomialsAndFirstCoset | CacheMonomialsAndFriCosets => {
+                self.required_storages_count() > self.uninitialized_storages.len()
+            }
+            CacheEvaluationsAndMonomials
+            | CacheEvaluationsMonomialsAndFirstCoset
+            | CacheEvaluationsMonomialsAndFriCosets
+            | CacheEvaluationsAndAllCosets => false,
+        };
+        assert!(can_owns_evaluations || !must_own_evaluations);
+        let monomials = match self.strategy {
+            InPlace | CacheMonomials | CacheMonomialsAndFirstCoset | CacheMonomialsAndFriCosets
+                if must_own_evaluations =>
+            {
+                Rc::into_inner(evaluations).unwrap().into_monomials()?
+            }
+            InPlace | CacheMonomials | CacheMonomialsAndFirstCoset | CacheMonomialsAndFriCosets => {
+                evaluations.fill_monomials(self.pop_storage())?
+            }
+            CacheEvaluationsAndMonomials
+            | CacheEvaluationsMonomialsAndFirstCoset
+            | CacheEvaluationsMonomialsAndFriCosets
+            | CacheEvaluationsAndAllCosets => {
+                let monomials = evaluations.fill_monomials(self.pop_storage())?;
+                self.evaluations = Some(evaluations);
+                monomials
+            }
+        };
+        let mut monomials = Some(monomials);
+        let cosets_count = match self.strategy {
+            CacheEvaluationsAndAllCosets => self.used_lde_degree,
+            _ => self.fri_lde_degree,
+        };
+        let coset_cap_size = coset_cap_size(self.cap_size, self.fri_lde_degree);
+        for coset_idx in 0..cosets_count {
+            let coset = match self.strategy {
+                InPlace => monomials
+                    .take()
+                    .unwrap()
+                    .into_coset_evaluations(coset_idx, self.used_lde_degree)?,
+                CacheMonomials | CacheEvaluationsAndMonomials => monomials
+                    .as_ref()
+                    .unwrap()
+                    .create_coset_evaluations(coset_idx, self.used_lde_degree)?,
+                CacheMonomialsAndFirstCoset | CacheEvaluationsMonomialsAndFirstCoset
+                    if coset_idx == 0 =>
+                {
+                    monomials.as_ref().unwrap().fill_coset_evaluations(
+                        coset_idx,
+                        self.used_lde_degree,
+                        self.pop_storage(),
+                    )?
+                }
+                CacheMonomialsAndFriCosets | CacheEvaluationsMonomialsAndFriCosets
+                    if coset_idx < self.fri_lde_degree =>
+                {
+                    monomials.as_ref().unwrap().fill_coset_evaluations(
+                        coset_idx,
+                        self.used_lde_degree,
+                        self.pop_storage(),
+                    )?
+                }
+                CacheMonomialsAndFirstCoset
+                | CacheMonomialsAndFriCosets
+                | CacheEvaluationsMonomialsAndFirstCoset
+                | CacheEvaluationsMonomialsAndFriCosets => monomials
+                    .as_ref()
+                    .unwrap()
+                    .create_coset_evaluations(coset_idx, self.used_lde_degree)?,
+                CacheEvaluationsAndAllCosets => {
+                    if coset_idx + 1 == self.used_lde_degree {
+                        monomials
+                            .take()
+                            .unwrap()
+                            .into_coset_evaluations(coset_idx, self.used_lde_degree)?
+                    } else {
+                        monomials.as_ref().unwrap().fill_coset_evaluations(
+                            coset_idx,
+                            self.used_lde_degree,
+                            self.pop_storage(),
+                        )?
+                    }
+                }
+            };
+            if coset_idx < self.fri_lde_degree {
+                let coset_nodes = self.uninitialized_subtree_nodes.pop().unwrap();
+                let (subtree, subtree_cap) =
+                    coset.build_subtree_for_coset(coset_cap_size, coset_idx, coset_nodes)?;
+                self.subtrees_and_caps
+                    .insert(coset_idx, (subtree, subtree_cap));
+            }
+
+            match self.strategy {
+                InPlace => {
+                    monomials = Some(coset.into_monomials(coset_idx, self.used_lde_degree)?);
+                }
+                CacheMonomials | CacheEvaluationsAndMonomials => {}
+                CacheMonomialsAndFirstCoset | CacheEvaluationsMonomialsAndFirstCoset
+                    if coset_idx == 0 =>
+                {
+                    self.coset_evaluations.insert(coset_idx, Rc::new(coset));
+                }
+                CacheMonomialsAndFriCosets | CacheEvaluationsMonomialsAndFriCosets
+                    if coset_idx < self.fri_lde_degree =>
+                {
+                    self.coset_evaluations.insert(coset_idx, Rc::new(coset));
+                }
+                CacheMonomialsAndFirstCoset
+                | CacheMonomialsAndFriCosets
+                | CacheEvaluationsMonomialsAndFirstCoset
+                | CacheEvaluationsMonomialsAndFriCosets => {}
+                CacheEvaluationsAndAllCosets => {
+                    self.coset_evaluations.insert(coset_idx, Rc::new(coset));
+                }
+            };
+        }
+        match self.strategy {
+            CacheEvaluationsAndAllCosets => {}
+            _ => {
+                self.monomials = Some(Rc::new(monomials.take().unwrap()));
+            }
+        };
+        Ok(())
+    }
+
+    pub fn num_polys(&self) -> usize {
+        self.layout.num_polys()
+    }
+
+    pub fn get_evaluations(&mut self) -> CudaResult<Rc<GenericStorage<LagrangeBasis, L>>> {
+        let result = match self.strategy {
+            InPlace => {
+                if let Some(evaluations) = &self.evaluations {
+                    evaluations.clone()
+                } else {
+                    let monomials = self.get_monomials()?;
+                    drop(self.monomials.take());
+                    let monomials = Rc::into_inner(monomials).unwrap();
+                    let evaluations = Rc::new(monomials.into_evaluations()?);
+                    self.evaluations = Some(evaluations.clone());
+                    evaluations
+                }
+            }
+            CacheMonomials | CacheMonomialsAndFirstCoset | CacheMonomialsAndFriCosets => {
+                Rc::new(self.monomials.as_ref().unwrap().create_evaluations()?)
+            }
+            _ => self.evaluations.as_ref().unwrap().clone(),
+        };
+        Ok(result)
+    }
+
+    pub fn get_monomials(&mut self) -> CudaResult<Rc<GenericStorage<MonomialBasis, L>>> {
+        let result = match self.strategy {
+            InPlace => {
+                if let Some(monomials) = &self.monomials {
+                    monomials.clone()
+                } else {
+                    let monomials = if let Some(evaluations) = self.evaluations.take() {
+                        let evaluations = Rc::into_inner(evaluations).unwrap();
+                        evaluations.into_monomials()?
+                    } else {
+                        let (coset_idx, coset) = self.coset_evaluations.pop_first().unwrap();
+                        assert!(self.coset_evaluations.is_empty());
+                        let coset = Rc::into_inner(coset).unwrap();
+                        coset.into_monomials(coset_idx, self.used_lde_degree)?
+                    };
+                    let monomials = Rc::new(monomials);
+                    self.monomials = Some(monomials.clone());
+                    monomials
+                }
+            }
+            CacheEvaluationsAndAllCosets => {
+                let (coset_idx, coset) = self.coset_evaluations.first_key_value().unwrap();
+                let monomials = coset.create_monomials(*coset_idx, self.used_lde_degree)?;
+                Rc::new(monomials)
+            }
+            _ => self.monomials.as_ref().unwrap().clone(),
+        };
+        Ok(result)
+    }
+
+    pub fn get_coset_evaluations(
+        &mut self,
+        coset_idx: usize,
+    ) -> CudaResult<Rc<GenericStorage<CosetEvaluations, L>>> {
+        assert!(coset_idx < self.used_lde_degree);
+        let result = match self.strategy {
+            InPlace => {
+                if let Some(coset) = self.coset_evaluations.get(&coset_idx) {
+                    coset.clone()
+                } else {
+                    let monomials = self.get_monomials()?;
+                    drop(self.monomials.take());
+                    let monomials = Rc::into_inner(monomials).unwrap();
+                    let coset =
+                        Rc::new(monomials.into_coset_evaluations(coset_idx, self.used_lde_degree)?);
+                    self.coset_evaluations.insert(coset_idx, coset.clone());
+                    coset
+                }
+            }
+            CacheMonomialsAndFirstCoset | CacheEvaluationsMonomialsAndFirstCoset
+                if coset_idx == 0 =>
+            {
+                self.coset_evaluations.get(&coset_idx).unwrap().clone()
+            }
+            CacheMonomialsAndFriCosets | CacheEvaluationsMonomialsAndFriCosets
+                if coset_idx < self.fri_lde_degree =>
+            {
+                self.coset_evaluations.get(&coset_idx).unwrap().clone()
+            }
+            CacheMonomials
+            | CacheMonomialsAndFirstCoset
+            | CacheMonomialsAndFriCosets
+            | CacheEvaluationsAndMonomials
+            | CacheEvaluationsMonomialsAndFirstCoset
+            | CacheEvaluationsMonomialsAndFriCosets => Rc::new(
+                self.monomials
+                    .as_ref()
+                    .unwrap()
+                    .create_coset_evaluations(coset_idx, self.used_lde_degree)?,
+            ),
+            CacheEvaluationsAndAllCosets => self.coset_evaluations.get(&coset_idx).unwrap().clone(),
+        };
+        Ok(result)
+    }
+
+    #[allow(dead_code)]
+    pub fn get_coset_evaluations_subset(
+        &mut self,
+        coset_idx: usize,
+        subset: L::PolyType,
+    ) -> CudaResult<Rc<GenericStorage<CosetEvaluations, L>>> {
+        assert!(coset_idx < self.used_lde_degree);
+        let result = match self.strategy {
+            InPlace | CacheEvaluationsAndAllCosets => self.get_coset_evaluations(coset_idx)?,
+            CacheMonomialsAndFirstCoset | CacheEvaluationsMonomialsAndFirstCoset
+                if coset_idx == 0 =>
+            {
+                self.coset_evaluations.get(&coset_idx).unwrap().clone()
+            }
+            CacheMonomialsAndFriCosets | CacheEvaluationsMonomialsAndFriCosets
+                if coset_idx < self.fri_lde_degree =>
+            {
+                self.coset_evaluations.get(&coset_idx).unwrap().clone()
+            }
+            CacheMonomials
+            | CacheMonomialsAndFirstCoset
+            | CacheMonomialsAndFriCosets
+            | CacheEvaluationsAndMonomials
+            | CacheEvaluationsMonomialsAndFirstCoset
+            | CacheEvaluationsMonomialsAndFriCosets => Rc::new(
+                self.monomials
+                    .as_ref()
+                    .unwrap()
+                    .create_coset_evaluations_subset(coset_idx, self.used_lde_degree, subset)?,
+            ),
+        };
+        Ok(result)
+    }
+
+    pub fn get_commitment<H: TreeHasher<F, Output = [F; 4]>>(
+        &mut self,
+        cap_size: usize,
+    ) -> CudaResult<(Vec<SubTree>, Vec<[F; 4]>)> {
+        let fri_lde_degree = self.fri_lde_degree;
+        let coset_cap_size = coset_cap_size(cap_size, self.fri_lde_degree);
+        let mut subtrees = vec![];
+        let mut subtree_caps = vec![];
+        for coset_idx in 0..fri_lde_degree {
+            let (subtree, subtree_cap) = &self.subtrees_and_caps.get(&coset_idx).unwrap();
+            assert_eq!(subtree.cap_size, coset_cap_size);
+            let subtree = SubTree::new(
+                subtree.nodes.clone(),
+                subtree.num_leafs,
+                subtree.cap_size,
+                coset_idx,
+            );
+            subtrees.push(subtree);
+            subtree_caps.push(subtree_cap.clone());
+        }
+        let tree_cap = subtree_caps.compute_cap::<H>(&mut subtrees, cap_size)?;
+        Ok((subtrees, tree_cap))
+    }
+
+    pub fn batch_query_for_coset<H: TreeHasher<F, Output = [F; 4]>, A: GoodAllocator>(
+        &mut self,
+        coset_idx: usize,
+        indexes: &DVec<u32, SmallStaticDeviceAllocator>,
+        num_queries: usize,
+        domain_size: usize,
+        h_all_leaf_elems: &mut Vec<F, A>,
+        h_all_proofs: &mut Vec<F, A>,
+    ) -> CudaResult<()> {
+        let leaf_sources = self.get_coset_evaluations(coset_idx)?;
+        let (oracle_data, _) = self.subtrees_and_caps.get(&coset_idx).unwrap();
+        batch_query::<H, A>(
+            indexes,
+            num_queries,
+            leaf_sources.deref(),
+            leaf_sources.num_polys(),
+            oracle_data,
+            oracle_data.cap_size,
+            domain_size,
+            1,
+            h_all_leaf_elems,
+            h_all_proofs,
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug, Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) struct CacheStrategy {
+    pub(crate) setup: StorageCacheStrategy,
+    pub(crate) trace: StorageCacheStrategy,
+    pub(crate) arguments: StorageCacheStrategy,
+}
+
+impl CacheStrategy {
+    pub(crate) fn get<
+        P: PrimeFieldLikeVectorized<Base = F>,
+        TR: Transcript<F, CompatibleCap = [F; 4]>,
+        H: TreeHasher<F, Output = TR::CompatibleCap>,
+        POW: PoWRunner,
+        A: GoodAllocator,
+    >(
+        cs: &CSReferenceAssembly<F, P, ProvingCSConfig>,
+        external_witness_data: &WitnessVec<F>,
+        proof_config: ProofConfig,
+        setup: &GpuSetup<A>,
+        vk: &VerificationKey<F, H>,
+        transcript_params: TR::TransciptParameters,
+        worker: &Worker,
+    ) -> CudaResult<Self> {
+        let cap = &vk.setup_merkle_tree_cap;
+        if let Some(strategy) = _strategy_cache_get().get(cap) {
+            println!("reusing cache strategy");
+            Ok(*strategy)
+        } else {
+            let strategies = Self::get_strategy_candidates(cs, &proof_config, setup);
+            for (_, strategy) in strategies.iter().copied() {
+                _setup_cache_reset();
+                dry_run_start();
+                let result =
+                    gpu_prove_from_external_witness_data_with_cache_strategy::<P, TR, H, POW, A>(
+                        cs,
+                        external_witness_data,
+                        proof_config.clone(),
+                        setup,
+                        vk,
+                        transcript_params.clone(),
+                        worker,
+                        strategy,
+                    );
+                _setup_cache_reset();
+                let result = result.and(dry_run_stop());
+                match result {
+                    Ok(_) => {
+                        println!("determined cache strategy: {:?}", strategy);
+                        _strategy_cache_get().insert(cap.clone(), strategy);
+                        return Ok(strategy);
+                    }
+                    Err(ErrorMemoryAllocation) => {
+                        continue;
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+            Err(ErrorMemoryAllocation)
+        }
+    }
+
+    pub(crate) fn get_strategy_candidates<
+        P: PrimeFieldLikeVectorized<Base = F>,
+        A: GoodAllocator,
+    >(
+        cs: &CSReferenceAssembly<F, P, ProvingCSConfig>,
+        proof_config: &ProofConfig,
+        setup: &GpuSetup<A>,
+    ) -> Vec<((usize, usize), CacheStrategy)> {
+        let fri_lde_degree = proof_config.fri_lde_factor;
+        let quotient_degree = compute_quotient_degree(&cs, &setup.selectors_placement);
+        let used_lde_degree = usize::max(quotient_degree, fri_lde_degree);
+        let setup_layout = setup.layout;
+        let trace_layout = TraceLayout {
+            num_variable_cols: setup.variables_hint.len(),
+            num_witness_cols: setup.witnesses_hint.len(),
+            num_multiplicity_cols: cs.num_multipicities_polys(),
+        };
+        let arguments_layout = ArgumentsLayout::from_trace_layout_and_lookup_params(
+            trace_layout,
+            quotient_degree,
+            cs.lookup_parameters.clone(),
+        );
+        let setup_num_polys = setup_layout.num_polys();
+        let trace_num_polys = trace_layout.num_polys();
+        let arguments_num_polys = arguments_layout.num_polys();
+        let setup_strategies = [
+            InPlace,
+            CacheMonomials,
+            CacheMonomialsAndFirstCoset,
+            CacheMonomialsAndFriCosets,
+            CacheEvaluationsAndMonomials,
+            CacheEvaluationsMonomialsAndFirstCoset,
+            CacheEvaluationsMonomialsAndFriCosets,
+            CacheEvaluationsAndAllCosets,
+        ];
+        let trace_and_arguments_strategies = [
+            InPlace,
+            CacheMonomials,
+            CacheMonomialsAndFirstCoset,
+            CacheMonomialsAndFriCosets,
+        ];
+        let mut strategies = Vec::new();
+        for setup_strategy in setup_strategies.iter().copied() {
+            for trace_strategy in trace_and_arguments_strategies.iter().copied() {
+                for arguments_strategy in trace_and_arguments_strategies.iter().copied() {
+                    let strategy = Self {
+                        setup: setup_strategy,
+                        trace: trace_strategy,
+                        arguments: arguments_strategy,
+                    };
+                    let setup_cost =
+                        strategy.get_setup_cost(fri_lde_degree, used_lde_degree) * setup_num_polys;
+                    let proof_cost_setup = strategy
+                        .get_proof_cost_setup(fri_lde_degree, used_lde_degree)
+                        * setup_num_polys;
+                    let proof_cost_trace = strategy
+                        .get_proof_cost_trace(fri_lde_degree, used_lde_degree)
+                        * trace_num_polys;
+                    let proof_cost_arguments = strategy
+                        .get_proof_cost_arguments(fri_lde_degree, used_lde_degree)
+                        * arguments_num_polys;
+                    let proof_cost = proof_cost_setup + proof_cost_trace + proof_cost_arguments;
+                    strategies.push(((proof_cost, setup_cost), strategy));
+                }
+            }
+        }
+        strategies.sort_by_key(|x| x.0);
+        strategies
+    }
+
+    fn get_setup_cost(&self, fri_lde_degree: usize, used_lde_degree: usize) -> usize {
+        let f = fri_lde_degree;
+        let u = used_lde_degree;
+        match self.setup {
+            InPlace => 1 + 2 * f,
+            CacheMonomials
+            | CacheMonomialsAndFirstCoset
+            | CacheMonomialsAndFriCosets
+            | CacheEvaluationsAndMonomials
+            | CacheEvaluationsMonomialsAndFirstCoset
+            | CacheEvaluationsMonomialsAndFriCosets => 1 + f,
+            CacheEvaluationsAndAllCosets => 1 + u,
+        }
+    }
+
+    fn get_proof_cost_setup(&self, fri_lde_degree: usize, used_lde_degree: usize) -> usize {
+        let f = fri_lde_degree;
+        let u = used_lde_degree;
+        match self.setup {
+            InPlace => 2 + 2 * u + 2 + 2 * (f - 1) + 2 * f,
+            CacheMonomials => 1 + u + 1 + f + f,
+            CacheMonomialsAndFirstCoset => 1 + u - 1 + f - 1 + f - 1,
+            CacheMonomialsAndFriCosets => 1 + u - f,
+            CacheEvaluationsAndMonomials => u + 1 + f + f,
+            CacheEvaluationsMonomialsAndFirstCoset => u - 1 + f - 1 + f - 1,
+            CacheEvaluationsMonomialsAndFriCosets => u - f,
+            CacheEvaluationsAndAllCosets => 0,
+        }
+    }
+
+    fn get_proof_cost_trace(&self, fri_lde_degree: usize, used_lde_degree: usize) -> usize {
+        let f = fri_lde_degree;
+        let u = used_lde_degree;
+        match self.trace {
+            InPlace => 1 + 2 * f + 1 + 2 * u + 2 + 2 * (f - 1) + 2 * f,
+            CacheMonomials => 1 + f + u + 1 + f + f,
+            CacheMonomialsAndFirstCoset => 1 + f + u - 1 + f - 1 + f - 1,
+            CacheMonomialsAndFriCosets => 1 + f + u - f,
+            CacheEvaluationsAndMonomials => 1 + f + u + 1 + f + f,
+            CacheEvaluationsMonomialsAndFirstCoset => 1 + f + u - 1 + f - 1 + f - 1,
+            CacheEvaluationsMonomialsAndFriCosets => 1 + f + u - f,
+            CacheEvaluationsAndAllCosets => 1 + u,
+        }
+    }
+
+    fn get_proof_cost_arguments(&self, fri_lde_degree: usize, used_lde_degree: usize) -> usize {
+        let f = fri_lde_degree;
+        let u = used_lde_degree;
+        match self.arguments {
+            InPlace => 1 + 2 * f + 2 * u - 1 + 1 + 1 + 2 * (f - 1) + 2 * f,
+            CacheMonomials => 1 + f + u + 1 + f + f,
+            CacheMonomialsAndFirstCoset => 1 + f + u - 1 + f - 1 + f - 1,
+            CacheMonomialsAndFriCosets => 1 + f + u - f,
+            CacheEvaluationsAndMonomials => 1 + f + u + 1 + f + f,
+            CacheEvaluationsMonomialsAndFirstCoset => 1 + f + u - 1 + f - 1 + f - 1,
+            CacheEvaluationsMonomialsAndFriCosets => 1 + f + u - f,
+            CacheEvaluationsAndAllCosets => 1 + u,
+        }
+    }
+}

--- a/src/data_structures/mod.rs
+++ b/src/data_structures/mod.rs
@@ -12,12 +12,11 @@ pub use setup::*;
 mod arguments;
 pub use arguments::*;
 
+mod cache;
+pub use cache::*;
+
 mod tree;
 pub use tree::*;
-
-use boojum::cs::traits::GoodAllocator;
-
-use cudart::event::CudaEventCreateFlags;
 
 pub trait AsSingleSlice {
     fn domain_size(&self) -> usize;

--- a/src/data_structures/storage.rs
+++ b/src/data_structures/storage.rs
@@ -1,13 +1,37 @@
 use super::*;
+use std::fmt::Debug;
+use std::marker::PhantomData;
+use std::ops::Range;
+use std::rc::Rc;
 
-#[derive(Clone)]
-pub struct GenericStorage {
-    pub(crate) inner: DVec<F>,
-    pub(crate) num_polys: usize,
-    pub(crate) domain_size: usize,
+pub trait GenericStorageLayout: Debug + Copy + Clone + Eq + PartialEq {
+    type PolyType: Copy + Clone;
+    fn num_polys(&self) -> usize;
+    fn poly_range(&self, poly_type: Self::PolyType) -> (Range<usize>, Self);
 }
 
-impl AsSingleSlice for GenericStorage {
+impl GenericStorageLayout for usize {
+    type PolyType = ();
+
+    fn num_polys(&self) -> usize {
+        *self
+    }
+
+    fn poly_range(&self, _: Self::PolyType) -> (Range<usize>, Self) {
+        (0..*self, *self)
+    }
+}
+
+#[derive(Clone)]
+pub struct GenericStorage<P: PolyForm, L: GenericStorageLayout> {
+    pub(crate) inner: DVec<F>,
+    pub(crate) layout: L,
+    pub(crate) num_polys: usize,
+    pub(crate) domain_size: usize,
+    poly_form: PhantomData<P>,
+}
+
+impl<P: PolyForm, L: GenericStorageLayout> AsSingleSlice for GenericStorage<P, L> {
     fn domain_size(&self) -> usize {
         self.domain_size
     }
@@ -25,22 +49,25 @@ impl AsSingleSlice for GenericStorage {
     }
 }
 
-impl GenericStorage {
-    pub fn allocate(num_polys: usize, domain_size: usize) -> CudaResult<Self> {
-        let storage = dvec!(num_polys * domain_size);
-        Ok(Self {
-            inner: storage,
+impl<P: PolyForm, L: GenericStorageLayout> GenericStorage<P, L> {
+    pub fn new(inner: DVec<F>, layout: L, domain_size: usize) -> Self {
+        let num_polys = layout.num_polys();
+        assert_eq!(inner.len(), num_polys * domain_size);
+        Self {
+            inner,
+            layout,
             num_polys,
             domain_size,
-        })
+            poly_form: PhantomData,
+        }
     }
 
-    #[allow(dead_code)]
-    pub fn into_poly_storage<P: PolyForm>(self) -> GenericPolynomialStorage<'static, P> {
+    pub fn into_poly_storage(self) -> GenericPolynomialStorage<'static, P> {
         let Self {
             inner,
             num_polys,
             domain_size,
+            ..
         } = self;
         let chunks = inner.into_adjacent_chunks(domain_size);
         assert_eq!(chunks.len(), num_polys);
@@ -54,33 +81,49 @@ impl GenericStorage {
         new
     }
 
-    pub fn as_poly_storage<'a, P: PolyForm>(&'a self) -> Vec<Poly<'a, P>> {
-        let Self {
-            inner,
-            num_polys,
-            domain_size,
-        } = self;
-        let num_polys = *num_polys;
-        let domain_size = *domain_size;
-        let mut storage_ref = &inner[..];
-        let mut all_polys_ref = vec![];
-        for _ in 0..num_polys {
-            let (values, remaining) = storage_ref.split_at(domain_size);
-            let poly = Poly::<'a, P>::from(values);
-            all_polys_ref.push(poly);
-            storage_ref = remaining;
-        }
-        assert_eq!(all_polys_ref.len() * domain_size, inner.len());
-        all_polys_ref
+    pub fn as_polys(&self) -> Vec<Poly<P>> {
+        self.inner
+            .chunks(self.domain_size)
+            .map(Poly::from)
+            .collect()
     }
 
-    pub fn into_complex_poly_storage<P: PolyForm>(
+    #[allow(dead_code)]
+    pub fn as_polys_mut(&mut self) -> Vec<Poly<P>> {
+        self.inner
+            .chunks_mut(self.domain_size)
+            .map(Poly::from)
+            .collect()
+    }
+
+    pub fn as_complex_polys(&self) -> Vec<ComplexPoly<P>> {
+        assert_eq!(self.num_polys % 2, 0);
+        self.inner
+            .chunks(self.domain_size)
+            .map(Poly::from)
+            .array_chunks::<2>()
+            .map(|[c0, c1]| ComplexPoly::new(c0, c1))
+            .collect()
+    }
+
+    pub fn as_complex_polys_mut(&mut self) -> Vec<ComplexPoly<P>> {
+        assert_eq!(self.num_polys % 2, 0);
+        self.inner
+            .chunks_mut(self.domain_size)
+            .map(Poly::from)
+            .array_chunks::<2>()
+            .map(|[c0, c1]| ComplexPoly::new(c0, c1))
+            .collect()
+    }
+
+    pub fn into_complex_poly_storage(
         self,
     ) -> CudaResult<GenericComplexPolynomialStorage<'static, P>> {
         let Self {
             inner,
             num_polys,
             domain_size,
+            ..
         } = self;
         let chunks = inner.into_adjacent_chunks(domain_size);
         assert_eq!(chunks.len(), num_polys);
@@ -96,14 +139,241 @@ impl GenericStorage {
 
         Ok(new)
     }
+
+    pub unsafe fn transmute<U: PolyForm>(self) -> GenericStorage<U, L> {
+        GenericStorage::new(self.inner, self.layout, self.domain_size)
+    }
 }
 
-impl AsMut<DVec<F>> for GenericStorage {
+impl<L: GenericStorageLayout> GenericStorage<Undefined, L> {
+    pub fn allocate(layout: L, domain_size: usize) -> Self {
+        let num_polys = layout.num_polys();
+        let inner = dvec!(num_polys * domain_size);
+        Self::new(inner, layout, domain_size)
+    }
+}
+
+impl<L: GenericStorageLayout> GenericStorage<LagrangeBasis, L> {
+    pub fn into_monomials(mut self) -> CudaResult<GenericStorage<MonomialBasis, L>> {
+        let domain_size = self.domain_size;
+        let num_polys = self.num_polys;
+        let input = self.as_single_slice_mut();
+        ntt::batch_ntt(input, false, true, domain_size, num_polys)?;
+        ntt::batch_bitreverse(input, domain_size)?;
+        let result = unsafe { self.transmute() };
+        Ok(result)
+    }
+
+    pub fn fill_monomials(
+        &self,
+        mut storage: GenericStorage<Undefined, L>,
+    ) -> CudaResult<GenericStorage<MonomialBasis, L>> {
+        assert_eq!(storage.layout, self.layout);
+        let domain_size = self.domain_size;
+        assert_eq!(storage.domain_size, domain_size);
+        let num_polys = self.num_polys;
+        let inputs = self.as_single_slice();
+        let outputs = storage.as_single_slice_mut();
+        ntt::batch_ntt_into(inputs, outputs, false, true, domain_size, num_polys)?;
+        ntt::batch_bitreverse(outputs, domain_size)?;
+        let result = unsafe { storage.transmute() };
+        Ok(result)
+    }
+
+    #[allow(dead_code)]
+    pub fn create_monomials(&self) -> CudaResult<GenericStorage<MonomialBasis, L>> {
+        let storage = GenericStorage::allocate(self.layout, self.domain_size);
+        self.fill_monomials(storage)
+    }
+}
+
+impl<L: GenericStorageLayout> GenericStorage<MonomialBasis, L> {
+    pub fn into_evaluations(mut self) -> CudaResult<GenericStorage<LagrangeBasis, L>> {
+        let domain_size = self.domain_size;
+        let num_polys = self.num_polys;
+        let input = self.as_single_slice_mut();
+        ntt::batch_ntt(input, false, false, domain_size, num_polys)?;
+        ntt::batch_bitreverse(input, domain_size)?;
+        let evaluations = unsafe { self.transmute() };
+        Ok(evaluations)
+    }
+
+    pub fn fill_evaluations(
+        &self,
+        mut storage: GenericStorage<Undefined, L>,
+    ) -> CudaResult<GenericStorage<LagrangeBasis, L>> {
+        assert_eq!(storage.layout, self.layout);
+        let domain_size = self.domain_size;
+        assert_eq!(storage.domain_size, domain_size);
+        let num_polys = self.num_polys;
+        let inputs = self.as_single_slice();
+        let outputs = storage.as_single_slice_mut();
+        ntt::batch_ntt_into(inputs, outputs, false, false, domain_size, num_polys)?;
+        ntt::batch_bitreverse(outputs, domain_size)?;
+        let result = unsafe { storage.transmute() };
+        Ok(result)
+    }
+
+    pub fn create_evaluations(&self) -> CudaResult<GenericStorage<LagrangeBasis, L>> {
+        let storage = GenericStorage::allocate(self.layout, self.domain_size);
+        self.fill_evaluations(storage)
+    }
+
+    pub fn into_coset_evaluations(
+        mut self,
+        coset_idx: usize,
+        lde_degree: usize,
+    ) -> CudaResult<GenericStorage<CosetEvaluations, L>> {
+        let domain_size = self.domain_size;
+        let num_polys = self.num_polys;
+        let inputs = self.as_single_slice_mut();
+        ntt::batch_coset_ntt(inputs, coset_idx, domain_size, lde_degree, num_polys)?;
+        let result = unsafe { self.transmute() };
+        Ok(result)
+    }
+
+    pub fn fill_coset_evaluations(
+        &self,
+        coset_idx: usize,
+        lde_degree: usize,
+        mut storage: GenericStorage<Undefined, L>,
+    ) -> CudaResult<GenericStorage<CosetEvaluations, L>> {
+        assert_eq!(storage.layout, self.layout);
+        let domain_size = self.domain_size;
+        assert_eq!(storage.domain_size, domain_size);
+        let num_polys = self.num_polys;
+        let inputs = self.as_single_slice();
+        let outputs = storage.as_single_slice_mut();
+        ntt::batch_coset_ntt_into(
+            inputs,
+            outputs,
+            coset_idx,
+            domain_size,
+            lde_degree,
+            num_polys,
+        )?;
+        let result = unsafe { storage.transmute() };
+        Ok(result)
+    }
+
+    pub fn create_coset_evaluations(
+        &self,
+        coset_idx: usize,
+        lde_degree: usize,
+    ) -> CudaResult<GenericStorage<CosetEvaluations, L>> {
+        let storage = GenericStorage::allocate(self.layout, self.domain_size);
+        self.fill_coset_evaluations(coset_idx, lde_degree, storage)
+    }
+
+    pub fn fill_coset_evaluations_subset(
+        &self,
+        coset_idx: usize,
+        lde_degree: usize,
+        subset: L::PolyType,
+        mut storage: GenericStorage<Undefined, L>,
+    ) -> CudaResult<GenericStorage<CosetEvaluations, L>> {
+        let (range, layout) = self.layout.poly_range(subset);
+        assert!(range.end <= self.num_polys);
+        assert_eq!(storage.layout, layout);
+        let domain_size = self.domain_size;
+        assert_eq!(storage.domain_size(), domain_size);
+        let num_polys = range.len();
+        let inputs = &self.as_single_slice()[range.start * domain_size..range.end * domain_size];
+        let outputs = storage.as_single_slice_mut();
+        if num_polys != 0 {
+            ntt::batch_coset_ntt_into(
+                inputs,
+                outputs,
+                coset_idx,
+                domain_size,
+                lde_degree,
+                num_polys,
+            )?;
+        }
+        let result = unsafe { storage.transmute() };
+        Ok(result)
+    }
+
+    pub fn create_coset_evaluations_subset(
+        &self,
+        coset_idx: usize,
+        lde_degree: usize,
+        subset: L::PolyType,
+    ) -> CudaResult<GenericStorage<CosetEvaluations, L>> {
+        let (_, layout) = self.layout.poly_range(subset);
+        let storage = GenericStorage::allocate(layout, self.domain_size());
+        self.fill_coset_evaluations_subset(coset_idx, lde_degree, subset, storage)
+    }
+}
+
+impl<L: GenericStorageLayout> GenericStorage<CosetEvaluations, L> {
+    pub fn into_monomials(
+        mut self,
+        coset_idx: usize,
+        lde_degree: usize,
+    ) -> CudaResult<GenericStorage<MonomialBasis, L>> {
+        let domain_size = self.domain_size;
+        let num_polys = self.num_polys;
+        let inputs = self.as_single_slice_mut();
+        ntt::batch_inverse_coset_ntt(inputs, coset_idx, domain_size, lde_degree, num_polys)?;
+        let result = unsafe { self.transmute() };
+        Ok(result)
+    }
+
+    pub fn fill_monomials(
+        &self,
+        coset_idx: usize,
+        lde_degree: usize,
+        mut storage: GenericStorage<Undefined, L>,
+    ) -> CudaResult<GenericStorage<MonomialBasis, L>> {
+        assert_eq!(storage.layout, self.layout);
+        let domain_size = self.domain_size;
+        assert_eq!(storage.domain_size, domain_size);
+        let num_polys = self.num_polys;
+        let inputs = self.as_single_slice();
+        let outputs = storage.as_single_slice_mut();
+        ntt::batch_inverse_coset_ntt_into(
+            inputs,
+            outputs,
+            coset_idx,
+            domain_size,
+            lde_degree,
+            num_polys,
+        )?;
+        let result = unsafe { storage.transmute() };
+        Ok(result)
+    }
+
+    pub fn create_monomials(
+        &self,
+        coset_idx: usize,
+        lde_degree: usize,
+    ) -> CudaResult<GenericStorage<MonomialBasis, L>> {
+        let storage = GenericStorage::allocate(self.layout, self.domain_size);
+        self.fill_monomials(coset_idx, lde_degree, storage)
+    }
+
+    pub fn build_subtree_for_coset(
+        &self,
+        cap_size: usize,
+        coset_idx: usize,
+        mut nodes: DVec<F>,
+    ) -> CudaResult<(SubTree, Vec<[F; 4]>)> {
+        let domain_size = self.domain_size();
+        let leaf_sources = self.as_single_slice();
+        let subtree_root = compute_tree_cap(leaf_sources, &mut nodes, domain_size, cap_size, 1)?;
+        let subtree = SubTree::new(Rc::new(nodes), domain_size, cap_size, coset_idx);
+        Ok((subtree, subtree_root))
+    }
+}
+
+impl<P: PolyForm, L: GenericStorageLayout> AsMut<DVec<F>> for GenericStorage<P, L> {
     fn as_mut(&mut self) -> &mut DVec<F> {
         &mut self.inner
     }
 }
-impl AsRef<DVec<F>> for GenericStorage {
+
+impl<P: PolyForm, L: GenericStorageLayout> AsRef<DVec<F>> for GenericStorage<P, L> {
     fn as_ref(&self) -> &DVec<F> {
         &self.inner
     }
@@ -116,7 +386,8 @@ pub struct GenericPolynomialStorage<'a, P: PolyForm> {
 impl<'a, P: PolyForm> GenericPolynomialStorage<'a, P> {
     #[allow(dead_code)]
     pub fn allocate(num_polys: usize, domain_size: usize) -> CudaResult<Self> {
-        let storage = GenericStorage::allocate(num_polys, domain_size)?;
+        let storage = GenericStorage::allocate(num_polys, domain_size);
+        let storage = unsafe { storage.transmute() };
         Ok(storage.into_poly_storage())
     }
 
@@ -127,6 +398,14 @@ impl<'a, P: PolyForm> GenericPolynomialStorage<'a, P> {
 }
 
 impl<'a, P: PolyForm> AsSingleSlice for GenericPolynomialStorage<'a, P> {
+    fn domain_size(&self) -> usize {
+        self.polynomials[0].domain_size()
+    }
+
+    fn num_polys(&self) -> usize {
+        self.polynomials.len()
+    }
+
     fn as_single_slice(&self) -> &[F] {
         assert_adjacent_base(&self.polynomials);
         let num_polys = self.polynomials.len();
@@ -143,14 +422,6 @@ impl<'a, P: PolyForm> AsSingleSlice for GenericPolynomialStorage<'a, P> {
         unsafe {
             std::slice::from_raw_parts_mut(self.polynomials[0].storage.as_mut().as_mut_ptr(), len)
         }
-    }
-
-    fn domain_size(&self) -> usize {
-        self.polynomials[0].domain_size()
-    }
-
-    fn num_polys(&self) -> usize {
-        self.polynomials.len()
     }
 }
 
@@ -180,6 +451,14 @@ impl<'a> LeafSourceQuery for GenericComplexPolynomialStorage<'a, CosetEvaluation
 }
 
 impl<'a, P: PolyForm> AsSingleSlice for GenericComplexPolynomialStorage<'a, P> {
+    fn domain_size(&self) -> usize {
+        self.polynomials[0].domain_size()
+    }
+
+    fn num_polys(&self) -> usize {
+        self.polynomials.len()
+    }
+
     fn as_single_slice(&self) -> &[F] {
         assert_adjacent_ext(&self.polynomials);
         let num_polys = 2 * self.polynomials.len();
@@ -200,52 +479,13 @@ impl<'a, P: PolyForm> AsSingleSlice for GenericComplexPolynomialStorage<'a, P> {
             )
         }
     }
-
-    fn domain_size(&self) -> usize {
-        self.polynomials[0].domain_size()
-    }
-
-    fn num_polys(&self) -> usize {
-        self.polynomials.len()
-    }
-}
-impl<'a, P: PolyForm> AsSingleSlice for &GenericComplexPolynomialStorage<'a, P> {
-    fn as_single_slice(&self) -> &[F] {
-        assert_adjacent_ext(&self.polynomials);
-        let num_polys = 2 * self.polynomials.len();
-        let domain_size = self.polynomials[0].domain_size();
-        let len = num_polys * domain_size;
-        unsafe { std::slice::from_raw_parts(self.polynomials[0].c0.storage.as_ref().as_ptr(), len) }
-    }
-
-    fn domain_size(&self) -> usize {
-        self.polynomials[0].domain_size()
-    }
-
-    fn num_polys(&self) -> usize {
-        self.polynomials.len()
-    }
 }
 
 impl<'a, P: PolyForm> GenericComplexPolynomialStorage<'a, P> {
     pub fn allocate(num_polys: usize, domain_size: usize) -> CudaResult<Self> {
-        let storage = GenericStorage::allocate(2 * num_polys, domain_size)?;
+        let storage = GenericStorage::allocate(2 * num_polys, domain_size);
+        let storage = unsafe { storage.transmute() };
         storage.into_complex_poly_storage()
-    }
-
-    pub fn clone(&self) -> CudaResult<Self> {
-        let num_polys = self.polynomials.len();
-        assert!(num_polys > 0);
-        let domain_size = self.polynomials[0].domain_size();
-
-        let mut new_storage = Self::allocate(num_polys, domain_size)?;
-
-        let src = self.as_single_slice();
-        let dst = new_storage.as_single_slice_mut();
-
-        mem::d2d(src, dst)?;
-
-        Ok(new_storage)
     }
 
     fn num_polys(&self) -> usize {
@@ -285,9 +525,9 @@ impl<'a> GenericComplexPolynomialStorage<'a, CosetEvaluations> {
         let domain_size = self.polynomials[0].domain_size();
         let leaf_sources = self.as_single_slice();
         let mut subtree = dvec!(2 * NUM_EL_PER_HASH * domain_size);
-        crate::primitives::tree::build_tree(leaf_sources, &mut subtree, domain_size, cap_size, 1)?;
+        primitives::tree::build_tree(leaf_sources, &mut subtree, domain_size, cap_size, 1)?;
         let subtree_root = get_tree_cap_from_nodes(&subtree, cap_size)?;
-        let subtree = SubTree::new(subtree, domain_size, cap_size, coset_idx);
+        let subtree = SubTree::new(Rc::new(subtree), domain_size, cap_size, coset_idx);
 
         Ok((subtree, subtree_root))
     }

--- a/src/data_structures/trace.rs
+++ b/src/data_structures/trace.rs
@@ -1,66 +1,68 @@
 use boojum::{
-    cs::{
-        implementations::{proof::OracleQuery, witness::WitnessVec},
-        oracle::TreeHasher,
-        traits::GoodAllocator,
-        LookupParameters,
-    },
+    cs::{implementations::witness::WitnessVec, traits::GoodAllocator, LookupParameters},
     field::U64Representable,
     worker::Worker,
 };
-use std::ops::Deref;
-use std::rc::Rc;
-
-use crate::cs::{variable_assignment, GpuSetup};
+use std::ops::Range;
 
 use super::*;
 
-#[derive(Clone, Debug)]
+use crate::cs::variable_assignment;
+use crate::data_structures::cache::StorageCache;
+
+#[allow(dead_code)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum TracePolyType {
+    Variable,
+    Witness,
+    Multiplicity,
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct TraceLayout {
     pub num_variable_cols: usize,
     pub num_witness_cols: usize,
     pub num_multiplicity_cols: usize,
 }
 
-impl TraceLayout {
-    pub fn num_polys(&self) -> usize {
+impl GenericStorageLayout for TraceLayout {
+    type PolyType = TracePolyType;
+
+    fn num_polys(&self) -> usize {
         self.num_variable_cols + self.num_witness_cols + self.num_multiplicity_cols
     }
-}
 
-#[derive(Clone)]
-pub struct GenericTraceStorage<P: PolyForm> {
-    pub storage: GenericStorage,
-    pub coset_idx: Option<usize>,
-    pub layout: TraceLayout,
-    form: std::marker::PhantomData<P>,
-}
-
-impl<P: PolyForm> GenericTraceStorage<P> {
-    pub fn allocate(domain_size: usize, layout: TraceLayout) -> CudaResult<Self> {
-        assert!(domain_size.is_power_of_two());
-        assert!(layout.num_variable_cols > 0);
-        let storage = GenericStorage::allocate(layout.num_polys(), domain_size)?;
-
-        let new = GenericTraceStorage {
-            storage,
-            coset_idx: None,
-            layout,
-            form: std::marker::PhantomData,
+    fn poly_range(&self, poly_type: Self::PolyType) -> (Range<usize>, Self) {
+        let start = match poly_type {
+            TracePolyType::Variable => 0,
+            TracePolyType::Witness => self.num_variable_cols,
+            TracePolyType::Multiplicity => self.num_variable_cols + self.num_witness_cols,
         };
-
-        Ok(new)
-    }
-    pub fn num_polys(&self) -> usize {
-        let num_polys = self.layout.num_polys();
-        assert_eq!(num_polys, self.storage.num_polys);
-        self.storage.num_polys
-    }
-
-    pub fn domain_size(&self) -> usize {
-        self.storage.domain_size
+        let len = match poly_type {
+            TracePolyType::Variable => self.num_variable_cols,
+            TracePolyType::Witness => self.num_witness_cols,
+            TracePolyType::Multiplicity => self.num_multiplicity_cols,
+        };
+        let range = start..start + len;
+        let layout = TraceLayout {
+            num_variable_cols: match poly_type {
+                TracePolyType::Variable => len,
+                _ => 0,
+            },
+            num_witness_cols: match poly_type {
+                TracePolyType::Witness => len,
+                _ => 0,
+            },
+            num_multiplicity_cols: match poly_type {
+                TracePolyType::Multiplicity => len,
+                _ => 0,
+            },
+        };
+        (range, layout)
     }
 }
+
+pub type GenericTraceStorage<P> = GenericStorage<P, TraceLayout>;
 
 impl<'a> LeafSourceQuery for TracePolynomials<'a, CosetEvaluations> {
     fn get_leaf_sources(
@@ -107,17 +109,14 @@ pub struct TracePolynomials<'a, P: PolyForm> {
 }
 
 impl<P: PolyForm> GenericTraceStorage<P> {
-    pub fn as_polynomials<'a>(&'a self) -> TracePolynomials<'a, P> {
-        let GenericTraceStorage {
-            storage, layout, ..
-        } = self;
+    pub fn as_polynomials(&self) -> TracePolynomials<P> {
         let TraceLayout {
             num_variable_cols,
             num_witness_cols,
             num_multiplicity_cols,
-        } = layout.clone();
+        } = self.layout;
 
-        let all_polys = storage.as_poly_storage();
+        let all_polys = self.as_polys();
         let mut all_polys_iter = all_polys.into_iter();
 
         let mut variable_cols = vec![];
@@ -144,430 +143,97 @@ impl<P: PolyForm> GenericTraceStorage<P> {
     }
 }
 
-pub fn construct_trace_storage_from_remote_witness_data<A: GoodAllocator>(
-    trace_layout: TraceLayout,
-    used_lde_degree: usize,
-    fri_lde_degree: usize,
-    domain_size: usize,
-    setup: &GpuSetup<A>,
-    witness_data: &WitnessVec<F>,
-    lookup_parameters: &LookupParameters,
-    worker: &Worker,
-) -> CudaResult<(
-    GenericTraceStorage<LagrangeBasis>,
-    GenericTraceStorage<MonomialBasis>,
-    Vec<SubTree>,
-    Vec<[F; 4]>,
-)> {
-    let num_polys = trace_layout.num_polys();
-    dbg!(num_polys);
-    dbg!(domain_size);
-
-    let TraceLayout {
-        num_variable_cols,
-        num_witness_cols,
-        num_multiplicity_cols,
-    } = trace_layout;
-
-    let GpuSetup {
-        variables_hint,
-        witnesses_hint,
-        setup_tree,
-        ..
-    } = setup;
-    let setup_root = setup_tree.get_cap();
-    let cap_size = setup_root.len();
-    dbg!(&cap_size); // TODO
-    assert_eq!(num_variable_cols, variables_hint.len());
-    assert_eq!(num_witness_cols, witnesses_hint.len());
-    assert!(num_multiplicity_cols <= 1);
-
-    let WitnessVec {
-        all_values,
-        multiplicities,
-        ..
-    } = witness_data;
-    // let inner_h2d_stream = CudaStream::create()?;
-    let inner_h2d_stream = get_stream();
-    let mut d_variable_values = dvec!(all_values.len());
-    mem::h2d_on_stream(&all_values, &mut d_variable_values, &inner_h2d_stream)?;
-
-    let mut raw_storage = GenericStorage::allocate(num_polys, domain_size)?;
-    let mut monomial_storage = GenericStorage::allocate(num_polys, domain_size)?;
-    let remaining_raw_storage = raw_storage.as_single_slice_mut();
-    let remaining_monomial_storage = monomial_storage.as_single_slice_mut();
-    assert_eq!(remaining_raw_storage.len(), num_polys * domain_size);
-    assert_eq!(remaining_monomial_storage.len(), num_polys * domain_size);
-    // assign variable values
-    let (variables_raw_storage, remaining_raw_storage) =
-        remaining_raw_storage.split_at_mut(num_variable_cols * domain_size);
-    let (variables_monomial_storage, remaining_monomial_storage) =
-        remaining_monomial_storage.split_at_mut(num_variable_cols * domain_size);
-
-    for ((variables, d_variables_raw), d_variables_monomial) in variables_hint
-        .iter()
-        .zip(variables_raw_storage.chunks_mut(domain_size))
-        .zip(variables_monomial_storage.chunks_mut(domain_size))
-    {
-        let transferred = CudaEvent::create_with_flags(CudaEventCreateFlags::DISABLE_TIMING)?;
-        let mut d_variable_indexes = dvec!(variables.len());
-        mem::h2d_on_stream(variables, &mut d_variable_indexes, &inner_h2d_stream)?;
-        transferred.record(&inner_h2d_stream)?;
-        get_stream().wait_event(&transferred, CudaStreamWaitEventFlags::DEFAULT)?;
-        variable_assignment(&d_variable_indexes, &d_variable_values, d_variables_raw)?;
-        let (_, padding) = d_variables_raw.split_at_mut(d_variable_indexes.len());
-        if !padding.is_empty() {
-            helpers::set_zero(padding)?;
+impl GenericTraceStorage<LagrangeBasis> {
+    pub fn fill_from_remote_witness_data(
+        variable_indexes: &DVec<u32>,
+        witness_indexes: &DVec<u32>,
+        witness_data: &WitnessVec<F>,
+        lookup_parameters: &LookupParameters,
+        worker: &Worker,
+        mut storage: GenericTraceStorage<Undefined>,
+    ) -> CudaResult<Self> {
+        let trace_layout = storage.layout.clone();
+        let num_polys = storage.num_polys();
+        let domain_size = storage.domain_size();
+        let TraceLayout {
+            num_variable_cols,
+            num_witness_cols,
+            num_multiplicity_cols,
+        } = trace_layout;
+        assert_eq!(num_variable_cols * domain_size, variable_indexes.len());
+        assert_eq!(num_witness_cols * domain_size, witness_indexes.len());
+        assert!(num_multiplicity_cols <= 1);
+        let WitnessVec {
+            all_values,
+            multiplicities,
+            ..
+        } = witness_data;
+        let mut d_variable_values = dvec!(all_values.len());
+        mem::h2d(&all_values, &mut d_variable_values)?;
+        let remaining_raw_storage = storage.as_single_slice_mut();
+        assert_eq!(remaining_raw_storage.len(), num_polys * domain_size);
+        let (variables_raw_storage, remaining_raw_storage) =
+            remaining_raw_storage.split_at_mut(num_variable_cols * domain_size);
+        variable_assignment(variable_indexes, &d_variable_values, variables_raw_storage)?;
+        let size_of_all_witness_cols = num_witness_cols * domain_size;
+        let (witnesses_raw_storage, multiplicities_raw_storage) =
+            remaining_raw_storage.split_at_mut(size_of_all_witness_cols);
+        if !witness_indexes.is_empty() {
+            variable_assignment(witness_indexes, &d_variable_values, witnesses_raw_storage)?;
+        } else {
+            assert!(witnesses_raw_storage.is_empty());
         }
-        ntt::intt_into(d_variables_raw, d_variables_monomial)?;
-        ntt::bitreverse(d_variables_monomial)?;
-    }
-
-    // now witness values
-    let size_of_all_witness_cols = num_witness_cols * domain_size;
-    let (witnesses_raw_storage, multiplicities_raw_storage) =
-        remaining_raw_storage.split_at_mut(size_of_all_witness_cols);
-    let (witnesses_monomial_storage, multiplicities_monomial_storage) =
-        remaining_monomial_storage.split_at_mut(size_of_all_witness_cols);
-    // hints may not be proper rectangular, so look for at least one non-empty col
-    let has_witnesses = witnesses_hint.iter().any(|v| !v.is_empty());
-    if has_witnesses {
-        for ((witnesses, d_witnesses_raw), d_witnesses_monomial) in witnesses_hint
-            .iter()
-            .zip(witnesses_raw_storage.chunks_mut(domain_size))
-            .zip(witnesses_monomial_storage.chunks_mut(domain_size))
-        {
-            let transferred = CudaEvent::create_with_flags(CudaEventCreateFlags::DISABLE_TIMING)?;
-            let mut d_witness_indexes = dvec!(witnesses.len());
-            mem::h2d_on_stream(witnesses, &mut d_witness_indexes, &inner_h2d_stream)?;
-            transferred.record(&inner_h2d_stream)?;
-            get_stream().wait_event(&transferred, CudaStreamWaitEventFlags::DEFAULT)?;
-            variable_assignment(&d_witness_indexes, &d_variable_values, d_witnesses_raw)?;
-            let (_, padding) = d_witnesses_raw.split_at_mut(d_witness_indexes.len());
+        drop(d_variable_values);
+        // we can transform and pad multiplicities on the host then transfer to the device
+        if lookup_parameters.lookup_is_allowed() {
+            let size_of_all_multiplicity_cols = num_multiplicity_cols * domain_size;
+            assert_eq!(
+                multiplicities_raw_storage.len(),
+                size_of_all_multiplicity_cols
+            );
+            let num_actual_multiplicities = multiplicities.len();
+            // we receive witness data from network so that they are minimal in size
+            // and may needs padding
+            assert!(num_actual_multiplicities <= multiplicities_raw_storage.len());
+            let mut transformed_multiplicities = vec![F::ZERO; num_actual_multiplicities];
+            if !is_dry_run()? {
+                worker.scope(num_actual_multiplicities, |scope, chunk_size| {
+                    for (src_chunk, dst_chunk) in multiplicities
+                        .chunks(chunk_size)
+                        .zip(transformed_multiplicities.chunks_mut(chunk_size))
+                    {
+                        scope.spawn(|_| {
+                            for (src, dst) in src_chunk.iter().zip(dst_chunk.iter_mut()) {
+                                *dst = F::from_u64_unchecked(*src as u64);
+                            }
+                        })
+                    }
+                });
+            }
+            let (actual_multiplicities_raw_storage, padding) =
+                multiplicities_raw_storage.split_at_mut(num_actual_multiplicities);
+            mem::h2d(
+                &transformed_multiplicities,
+                actual_multiplicities_raw_storage,
+            )?;
             if !padding.is_empty() {
                 helpers::set_zero(padding)?;
             }
-            ntt::intt_into(d_witnesses_raw, d_witnesses_monomial)?;
-            ntt::bitreverse(d_witnesses_monomial)?;
-        }
-    } else {
-        assert!(witnesses_raw_storage.is_empty());
-    }
-
-    // we can transform and pad multiplicities on the host then transfer to the device
-    // TODO: consider to make a select function which allows values that are generic in type
-    if lookup_parameters.lookup_is_allowed() {
-        let size_of_all_multiplicity_cols = num_multiplicity_cols * domain_size;
-        assert_eq!(
-            multiplicities_raw_storage.len(),
-            size_of_all_multiplicity_cols
-        );
-        assert_eq!(
-            multiplicities_monomial_storage.len(),
-            size_of_all_multiplicity_cols
-        );
-        let num_actual_multiplicities = multiplicities.len();
-        // we receive witness data from network so that they are minimal in size
-        // and may needs padding
-        assert!(num_actual_multiplicities <= multiplicities_raw_storage.len());
-        let mut transformed_multiplicities = vec![F::ZERO; num_actual_multiplicities];
-        worker.scope(num_actual_multiplicities, |scope, chunk_size| {
-            for (src_chunk, dst_chunk) in multiplicities
-                .chunks(chunk_size)
-                .zip(transformed_multiplicities.chunks_mut(chunk_size))
-            {
-                scope.spawn(|_| {
-                    for (src, dst) in src_chunk.iter().zip(dst_chunk.iter_mut()) {
-                        *dst = F::from_u64_unchecked(*src as u64);
-                    }
-                })
-            }
-        });
-        let (actual_multiplicities_raw_storage, padding) =
-            multiplicities_raw_storage.split_at_mut(num_actual_multiplicities);
-        let transferred = CudaEvent::create_with_flags(CudaEventCreateFlags::DISABLE_TIMING)?;
-        mem::h2d_on_stream(
-            &transformed_multiplicities,
-            actual_multiplicities_raw_storage,
-            &inner_h2d_stream,
-        )?;
-        transferred.record(&inner_h2d_stream)?;
-        if !padding.is_empty() {
-            helpers::set_zero(padding)?;
-        }
-        get_stream().wait_event(&transferred, CudaStreamWaitEventFlags::DEFAULT)?;
-        // Reminder to change ntt into batch ntt if we ever use more than one multiplicity col
-        assert_eq!(num_multiplicity_cols, 1);
-        ntt::intt_into(multiplicities_raw_storage, multiplicities_monomial_storage)?;
-        ntt::bitreverse(multiplicities_monomial_storage)?;
-    } else {
-        assert!(multiplicities_raw_storage.is_empty())
-    }
-
-    let raw_trace_storage = GenericTraceStorage {
-        storage: raw_storage,
-        coset_idx: None,
-        layout: trace_layout.clone(),
-        form: std::marker::PhantomData,
-    };
-    let monomial_trace_storage = GenericTraceStorage {
-        storage: monomial_storage,
-        coset_idx: None,
-        layout: trace_layout.clone(),
-        form: std::marker::PhantomData,
-    };
-    let coset_cap_size = coset_cap_size(cap_size, fri_lde_degree);
-    let mut first_coset_storage = GenericTraceStorage::allocate(domain_size, trace_layout.clone())?;
-    monomial_trace_storage.into_coset_eval(0, used_lde_degree, &mut first_coset_storage)?;
-    let (first_subtree, first_subtree_root) =
-        first_coset_storage.build_subtree_for_coset(coset_cap_size, 0)?;
-    let mut second_coset_storage =
-        GenericTraceStorage::allocate(domain_size, trace_layout.clone())?;
-    monomial_trace_storage.into_coset_eval(1, used_lde_degree, &mut second_coset_storage)?;
-    let (second_subree, second_subtree_root) =
-        second_coset_storage.build_subtree_for_coset(coset_cap_size, 1)?;
-
-    let mut subtrees = vec![first_subtree, second_subree];
-    let mut subtree_roots = vec![first_subtree_root, second_subtree_root];
-    let trace_tree_cap = subtree_roots.compute_cap::<DefaultTreeHasher>(&mut subtrees, cap_size)?;
-
-    Ok((
-        raw_trace_storage,
-        monomial_trace_storage,
-        subtrees,
-        trace_tree_cap,
-    ))
-}
-
-impl GenericTraceStorage<LagrangeBasis> {
-    #[allow(dead_code)]
-    pub fn into_monomials(&self) -> CudaResult<GenericTraceStorage<MonomialBasis>> {
-        let trace_layout = self.layout.clone();
-        let num_polys = trace_layout.num_polys();
-        let domain_size = self.domain_size();
-
-        let mut monomial_storage = GenericStorage::allocate(num_polys, domain_size)?;
-
-        ntt::batch_ntt_into(
-            self.storage.as_single_slice(),
-            monomial_storage.as_single_slice_mut(),
-            false,
-            true,
-            domain_size,
-            num_polys,
-        )?;
-
-        ntt::batch_bitreverse(monomial_storage.as_single_slice_mut(), domain_size)?;
-
-        let monomials = GenericTraceStorage {
-            storage: monomial_storage,
-            coset_idx: None,
-            layout: trace_layout,
-            form: std::marker::PhantomData,
+        } else {
+            assert!(multiplicities_raw_storage.is_empty())
         };
-
-        Ok(monomials)
-    }
-}
-
-impl GenericTraceStorage<MonomialBasis> {
-    pub fn into_coset_eval(
-        &self,
-        coset_idx: usize,
-        lde_degree: usize,
-        coset_storage: &mut GenericTraceStorage<CosetEvaluations>,
-    ) -> CudaResult<()> {
-        let num_polys = self.num_polys();
-        let Self { storage, .. } = self;
-        let domain_size = storage.domain_size;
-
-        // let mut coset_storage = GenericStorage::allocate(num_polys, domain_size)?;
-        ntt::batch_coset_ntt_into(
-            storage.as_ref(),
-            coset_storage.storage.as_mut(),
-            coset_idx,
-            domain_size,
-            lde_degree,
-            num_polys,
-        )?;
-
-        Ok(())
+        let result = unsafe { storage.transmute() };
+        Ok(result)
     }
 }
 
 impl GenericTraceStorage<CosetEvaluations> {
-    pub fn build_subtree_for_coset(
-        &self,
-        coset_cap_size: usize,
-        coset_idx: usize,
-    ) -> CudaResult<(SubTree, Vec<[F; 4]>)> {
-        let domain_size = self.domain_size();
-        let Self { storage, .. } = self;
-        let leaf_sources = <GenericStorage as AsRef<DVec<F>>>::as_ref(&storage);
-        let mut subtree = dvec!(2 * NUM_EL_PER_HASH * domain_size);
-        let subtree_root =
-            compute_tree_cap(leaf_sources, &mut subtree, domain_size, coset_cap_size, 1)?;
-        let subtree = SubTree::new(subtree, domain_size, coset_cap_size, coset_idx);
-        Ok((subtree, subtree_root))
-    }
-
     pub(crate) fn barycentric_evaluate<A: GoodAllocator>(
         &self,
         bases: &PrecomputedBasisForBarycentric,
     ) -> CudaResult<Vec<EF, A>> {
-        batch_barycentric_evaluate_base(&self.storage, bases, self.domain_size(), self.num_polys())
+        batch_barycentric_evaluate_base(self, bases, self.domain_size(), self.num_polys())
     }
 }
 
-impl AsSingleSlice for &GenericTraceStorage<CosetEvaluations> {
-    fn domain_size(&self) -> usize {
-        self.storage.domain_size()
-    }
-
-    fn num_polys(&self) -> usize {
-        GenericTraceStorage::num_polys(&self)
-    }
-
-    fn as_single_slice(&self) -> &[F] {
-        self.storage.as_single_slice()
-    }
-}
-
-// we want a holder that either
-// - recomputes coset evals each time
-// - or keeps coset evals
-pub struct TraceCache {
-    monomials: GenericTraceStorage<MonomialBasis>,
-    cosets: Vec<Option<Rc<GenericTraceStorage<CosetEvaluations>>>>,
-    fri_lde_degree: usize,
-    used_lde_degree: usize,
-}
-
-impl TraceCache {
-    pub fn from_monomial(
-        monomial_trace: GenericTraceStorage<MonomialBasis>,
-        fri_lde_degree: usize,
-        used_lde_degree: usize,
-    ) -> CudaResult<Self> {
-        assert!(fri_lde_degree.is_power_of_two());
-        assert!(used_lde_degree.is_power_of_two());
-        let cosets = vec![None; fri_lde_degree];
-        Ok(Self {
-            monomials: monomial_trace,
-            cosets,
-            fri_lde_degree,
-            used_lde_degree,
-        })
-    }
-
-    #[allow(dead_code)]
-    pub fn commit<H: TreeHasher<F, Output = [F; 4]>>(
-        &mut self,
-        cap_size: usize,
-    ) -> CudaResult<(Vec<SubTree>, Vec<[F; 4]>)> {
-        let fri_lde_degree = self.fri_lde_degree;
-        let coset_cap_size = coset_cap_size(cap_size, self.fri_lde_degree);
-        let mut trace_subtrees = vec![];
-        let mut trace_subtree_caps = vec![];
-
-        assert_eq!(self.cosets.len(), fri_lde_degree);
-
-        for coset_idx in 0..fri_lde_degree {
-            let coset_values = self.get_or_compute_coset_evals(coset_idx)?;
-            let (subtree, subtree_cap) =
-                coset_values.build_subtree_for_coset(coset_cap_size, coset_idx)?;
-            trace_subtree_caps.push(subtree_cap);
-            trace_subtrees.push(subtree);
-        }
-
-        let trace_tree_cap = trace_subtree_caps.compute_cap::<H>(&mut trace_subtrees, cap_size)?;
-
-        Ok((trace_subtrees, trace_tree_cap))
-    }
-
-    pub fn get_or_compute_coset_evals(
-        &mut self,
-        coset_idx: usize,
-    ) -> CudaResult<Rc<GenericTraceStorage<CosetEvaluations>>> {
-        assert!(coset_idx < self.used_lde_degree);
-
-        if REMEMBER_COSETS == false || coset_idx >= self.fri_lde_degree {
-            let mut tmp_coset = GenericTraceStorage::allocate(
-                self.monomials.domain_size(),
-                self.monomials.layout.clone(),
-            )?;
-            self.monomials
-                .into_coset_eval(coset_idx, self.used_lde_degree, &mut tmp_coset)?;
-            return Ok(Rc::new(tmp_coset));
-        }
-
-        if self.cosets[coset_idx].is_none() {
-            let mut current_storage = GenericTraceStorage::allocate(
-                self.monomials.domain_size(),
-                self.monomials.layout.clone(),
-            )?;
-            self.monomials.into_coset_eval(
-                coset_idx,
-                self.used_lde_degree,
-                &mut current_storage,
-            )?;
-            self.cosets[coset_idx] = Some(Rc::new(current_storage));
-        }
-
-        return Ok(self.cosets[coset_idx].as_ref().unwrap().clone());
-    }
-
-    #[allow(dead_code)]
-    pub fn query<H: TreeHasher<F, Output = [F; 4]>>(
-        &mut self,
-        coset_idx: usize,
-        fri_lde_degree: usize,
-        row_idx: usize,
-        domain_size: usize,
-        tree_holder: &TreeCache,
-    ) -> CudaResult<OracleQuery<F, H>> {
-        let leaf_sources = self.get_or_compute_coset_evals(coset_idx)?;
-        tree_holder.get_trace_subtrees().query(
-            &leaf_sources.as_polynomials(),
-            coset_idx,
-            fri_lde_degree,
-            row_idx,
-            domain_size,
-        )
-    }
-
-    pub fn batch_query_for_coset<H: TreeHasher<F, Output = [F; 4]>, A: GoodAllocator>(
-        &mut self,
-        coset_idx: usize,
-        indexes: &DVec<u32, SmallStaticDeviceAllocator>,
-        num_queries: usize,
-        domain_size: usize,
-        h_all_leaf_elems: &mut Vec<F, A>,
-        h_all_proofs: &mut Vec<F, A>,
-        tree_holder: &TreeCache,
-    ) -> CudaResult<()> {
-        let leaf_sources = self.get_or_compute_coset_evals(coset_idx)?;
-        let oracle_data = tree_holder.get_trace_subtree(coset_idx);
-        batch_query::<H, A>(
-            indexes,
-            num_queries,
-            leaf_sources.deref(),
-            leaf_sources.num_polys(),
-            oracle_data,
-            oracle_data.cap_size,
-            domain_size,
-            1,
-            h_all_leaf_elems,
-            h_all_proofs,
-        )
-    }
-
-    pub fn num_polys(&self) -> usize {
-        self.monomials.num_polys()
-    }
-
-    #[allow(dead_code)]
-    pub fn layout(&self) -> TraceLayout {
-        self.monomials.layout.clone()
-    }
-}
+pub type TraceCache = StorageCache<TraceLayout, ()>;

--- a/src/data_structures/tree.rs
+++ b/src/data_structures/tree.rs
@@ -58,6 +58,7 @@ impl TreeCache {
         self.get(OracleType::Trace)
     }
 
+    #[allow(dead_code)]
     pub fn get_trace_subtree(&self, coset_idx: usize) -> &SubTree {
         self.get_coset_subtree(OracleType::Trace, coset_idx)
     }
@@ -75,6 +76,7 @@ impl TreeCache {
         self.get(OracleType::Argument)
     }
 
+    #[allow(dead_code)]
     pub fn get_argument_subtree(&self, coset_idx: usize) -> &SubTree {
         self.get_coset_subtree(OracleType::Argument, coset_idx)
     }
@@ -97,6 +99,7 @@ impl TreeCache {
         self.get(OracleType::Setup)
     }
 
+    #[allow(dead_code)]
     pub fn get_setup_subtree(&self, coset_idx: usize) -> &SubTree {
         self.get_coset_subtree(OracleType::Setup, coset_idx)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ mod pow;
 mod utils;
 use utils::*;
 mod primitives;
+use primitives::dry_run::*;
 mod static_allocator;
 use static_allocator::*;
 mod dvec;
@@ -65,7 +66,3 @@ type DefaultTreeHasher = GoldilocksPoseidon2Sponge<AbsorptionModeOverwrite>;
 use boojum::cs::traits::GoodAllocator;
 pub use context::ProverContext;
 pub use prover::gpu_prove_from_external_witness_data;
-#[cfg(feature = "recompute")]
-pub(crate) const REMEMBER_COSETS: bool = false;
-#[cfg(not(feature = "recompute"))]
-pub(crate) const REMEMBER_COSETS: bool = true;

--- a/src/pow.rs
+++ b/src/pow.rs
@@ -21,19 +21,23 @@ impl PoWRunner for DeviceBlake2sPOW {
             let result_as_mut_slice =
                 std::slice::from_raw_parts_mut(result.as_mut_ptr() as *mut _, 1);
             let result_as_var = DeviceVariable::from_mut_slice(result_as_mut_slice);
-            boojum_cuda::blake2s::blake2s_pow(
-                seed,
-                pow_bits,
-                u64::MAX,
-                result_as_var,
-                get_stream(),
-            )
-            .expect("pow on device");
+            if !is_dry_run().unwrap() {
+                boojum_cuda::blake2s::blake2s_pow(
+                    seed,
+                    pow_bits,
+                    u64::MAX,
+                    result_as_var,
+                    get_stream(),
+                )
+                .expect("pow on device");
+            }
             let h_result: F = result.into();
             h_result.0
         };
 
-        assert!(Self::verify_from_bytes(h_seed, pow_bits, challenge));
+        if !is_dry_run().unwrap() {
+            assert!(Self::verify_from_bytes(h_seed, pow_bits, challenge));
+        }
 
         challenge
     }

--- a/src/primitives/cs_helpers.rs
+++ b/src/primitives/cs_helpers.rs
@@ -54,18 +54,18 @@ pub fn constraint_evaluation(
         domain_size,
     );
 
-    let _ = boojum_cuda::gates::evaluate_gates(
-        &gates,
-        &variable_columns_matrix,
-        &witness_columns_matrix,
-        &constant_columns_matrix,
-        challenge,
-        &mut quotient_matrix,
-        challenge_power_offset as u32,
-        get_stream(),
-    )?;
-
-    Ok(())
+    if_not_dry_run! {
+        boojum_cuda::gates::evaluate_gates(
+            &gates,
+            &variable_columns_matrix,
+            &witness_columns_matrix,
+            &constant_columns_matrix,
+            challenge,
+            &mut quotient_matrix,
+            challenge_power_offset as u32,
+            get_stream(),
+        ).map(|_| ())
+    }
 }
 
 #[allow(dead_code)]
@@ -106,16 +106,16 @@ pub fn constraint_evaluation_over_lde(
         lde_size,
     );
 
-    let _ = boojum_cuda::gates::evaluate_gates(
-        &gates,
-        &variable_columns_matrix,
-        &witness_columns_matrix,
-        &constant_columns_matrix,
-        challenge,
-        &mut quotient_matrix,
-        0,
-        get_stream(),
-    )?;
-
-    Ok(())
+    if_not_dry_run! {
+        boojum_cuda::gates::evaluate_gates(
+            &gates,
+            &variable_columns_matrix,
+            &witness_columns_matrix,
+            &constant_columns_matrix,
+            challenge,
+            &mut quotient_matrix,
+            0,
+            get_stream(),
+        ).map(|_| ())
+    }
 }

--- a/src/primitives/dry_run.rs
+++ b/src/primitives/dry_run.rs
@@ -1,0 +1,63 @@
+use cudart::result::CudaResult;
+use cudart_sys::CudaError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DryRunState {
+    Stopped,
+    Running,
+    Failing(CudaError),
+}
+
+use DryRunState::*;
+
+static mut DRY_RUN_STATE: DryRunState = Stopped;
+
+pub(crate) fn dry_run_start() {
+    unsafe {
+        assert_eq!(DRY_RUN_STATE, Stopped);
+        DRY_RUN_STATE = Running;
+    }
+}
+
+pub(crate) fn dry_run_stop() -> CudaResult<()> {
+    unsafe {
+        assert_ne!(DRY_RUN_STATE, Stopped);
+        let state = DRY_RUN_STATE;
+        DRY_RUN_STATE = Stopped;
+        if let Failing(e) = state {
+            Err(e)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+pub(crate) fn dry_run_fail(error: CudaError) {
+    unsafe {
+        assert_ne!(DRY_RUN_STATE, Stopped);
+        DRY_RUN_STATE = Failing(error);
+    }
+}
+
+pub(crate) fn is_dry_run() -> CudaResult<bool> {
+    unsafe {
+        match DRY_RUN_STATE {
+            Stopped => Ok(false),
+            Running => Ok(true),
+            Failing(e) => Err(e),
+        }
+    }
+}
+
+macro_rules! if_not_dry_run {
+    ($($t:tt)*) => {
+        if !crate::primitives::dry_run::is_dry_run()? {
+            $($t)*
+        }
+        else {
+            Ok(())
+        }
+    };
+}
+
+pub(crate) use if_not_dry_run;

--- a/src/primitives/mem.rs
+++ b/src/primitives/mem.rs
@@ -1,29 +1,35 @@
 use super::*;
+pub use cudart::memory::memory_copy_async;
 
 pub fn h2d<T>(host: &[T], device: &mut [T]) -> CudaResult<()> {
     assert!(!host.is_empty());
     assert_eq!(host.len(), device.len());
-    memory_copy_async(&mut device[..], host, get_h2d_stream())?;
-    Ok(())
+    if_not_dry_run! {
+        memory_copy_async(&mut device[..], host, get_h2d_stream())
+    }
 }
 
+#[allow(dead_code)]
 pub fn h2d_on_stream<T>(host: &[T], device: &mut [T], stream: &CudaStream) -> CudaResult<()> {
     assert!(!host.is_empty());
     assert_eq!(host.len(), device.len());
-    memory_copy_async(&mut device[..], host, stream)?;
-    Ok(())
+    if_not_dry_run! {
+        memory_copy_async(&mut device[..], host, stream)
+    }
 }
 
 pub fn d2h<T>(device: &[T], host: &mut [T]) -> CudaResult<()> {
     assert!(!host.is_empty());
     assert_eq!(host.len(), device.len());
-    memory_copy_async(host, &device[..], get_d2h_stream())?;
-    Ok(())
+    if_not_dry_run! {
+        memory_copy_async(host, &device[..], get_d2h_stream())
+    }
 }
 
 pub fn d2d<T>(src: &[T], dst: &mut [T]) -> CudaResult<()> {
     assert!(!src.is_empty());
     assert_eq!(src.len(), dst.len());
-    memory_copy_async(&mut dst[..], &src[..], get_stream())?;
-    Ok(())
+    if_not_dry_run! {
+        memory_copy_async(&mut dst[..], &src[..], get_stream())
+    }
 }

--- a/src/primitives/mod.rs
+++ b/src/primitives/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod arith;
 pub(crate) mod cs_helpers;
+pub(crate) mod dry_run;
 pub(crate) mod helpers;
 pub(crate) mod mem;
 pub(crate) mod ntt;
@@ -8,9 +9,7 @@ pub(crate) mod tree;
 use super::*;
 pub use ::boojum_cuda::gates::GateEvaluationParams;
 pub use boojum_cuda::context::Context as CudaContext;
-pub use cudart::event::CudaEvent;
-pub use cudart::memory::memory_copy_async;
 pub use cudart::result::CudaResult;
 use cudart::slice::CudaSlice;
 use cudart::slice::DeviceSlice;
-pub use cudart::stream::{CudaStream, CudaStreamWaitEventFlags};
+pub use cudart::stream::CudaStream;

--- a/src/primitives/tree.rs
+++ b/src/primitives/tree.rs
@@ -20,13 +20,15 @@ pub fn build_tree(
             DeviceSlice::from_mut_slice(result),
         )
     };
-    boojum_cuda::poseidon::build_merkle_tree::<P>(
-        leaf_sources,
-        result,
-        num_elems_per_leaf.trailing_zeros(),
-        get_stream(),
-        num_layers as u32,
-    )
+    if_not_dry_run! {
+        boojum_cuda::poseidon::build_merkle_tree::<P>(
+            leaf_sources,
+            result,
+            num_elems_per_leaf.trailing_zeros(),
+            get_stream(),
+            num_layers,
+        )
+    }
 }
 
 #[allow(dead_code)]
@@ -46,16 +48,16 @@ pub fn build_leaves_from_chunk(
             DeviceSlice::from_mut_slice(result),
         )
     };
-    boojum_cuda::poseidon::build_merkle_tree_leaves::<P>(
-        d_values,
-        d_result,
-        0,
-        load_intermediate,
-        store_intermediate,
-        get_stream(),
-    )?;
-
-    Ok(())
+    if_not_dry_run! {
+        boojum_cuda::poseidon::build_merkle_tree_leaves::<P>(
+            d_values,
+            d_result,
+            0,
+            load_intermediate,
+            store_intermediate,
+            get_stream(),
+        )
+    }
 }
 
 #[allow(dead_code)]
@@ -77,10 +79,12 @@ pub fn build_tree_nodes(
             DeviceSlice::from_mut_slice(result),
         )
     };
-    boojum_cuda::poseidon::build_merkle_tree_nodes::<P>(
-        leaf_sources,
-        result,
-        num_layers as u32,
-        get_stream(),
-    )
+    if_not_dry_run! {
+        boojum_cuda::poseidon::build_merkle_tree_nodes::<P>(
+            leaf_sources,
+            result,
+            num_layers,
+            get_stream(),
+        )
+    }
 }

--- a/src/quotient.rs
+++ b/src/quotient.rs
@@ -3,59 +3,66 @@ use boojum::cs::{implementations::setup::TreeNode, LookupParameters};
 use super::*;
 
 // The incoming quotient is assumed to be empty (not zeroed).
-pub fn compute_quotient_by_coset<'a, 'b>(
-    trace_storage: &'a GenericTraceStorage<CosetEvaluations>,
-    setup_storage: &'a GenericSetupStorage<CosetEvaluations>,
-    argument_storage: &'a GenericArgumentStorage<'a, CosetEvaluations>,
+pub fn compute_quotient_by_coset(
+    trace_cache: &mut TraceCache,
+    setup_cache: &mut SetupCache,
+    arguments_cache: &mut ArgumentsCache,
     lookup_params: LookupParameters,
     table_ids_column_idxes: &[usize],
     selector_placement: &TreeNode,
-    specialized_gates: &[cs_helpers::GateEvaluationParams],
-    general_purpose_gates: &[cs_helpers::GateEvaluationParams],
+    specialized_gates: &[GateEvaluationParams],
+    general_purpose_gates: &[GateEvaluationParams],
     coset_idx: usize,
     domain_size: usize,
     used_lde_degree: usize,
     num_cols_per_product: usize,
     copy_permutation_challenge_z_at_one_equals_one: &EF,
-    copy_permutation_challenges_partial_product_terms: &DVec<EF>,
+    copy_permutation_challenges_partial_product_terms: &SVec<EF>,
     alpha: &EF,
-    lookup_challenges: &Option<DVec<EF>>,
+    lookup_challenges: &Option<SVec<EF>>,
     specialized_cols_challenge_power_offset: usize,
     general_purpose_cols_challenge_power_offset: usize,
     beta: &DExt,
     gamma: &DExt,
-    powers_of_gamma_for_lookup: &Option<DVec<EF>>,
+    powers_of_gamma_for_lookup: &Option<SVec<EF>>,
     lookup_beta: Option<&DExt>,
-    non_residues_by_beta: &DVec<EF>,
+    non_residues_by_beta: &SVec<EF>,
     variables_offset: usize,
-    quotient: &mut ComplexPoly<'b, CosetEvaluations>,
-) -> CudaResult<()>
-where
-    'a: 'b,
-{
-    let trace_polys = trace_storage.as_polynomials();
-    let setup_polys = setup_storage.as_polynomials();
-    let argument_polys = argument_storage.as_polynomials();
+    quotient: &mut ComplexPoly<CosetEvaluations>,
+) -> CudaResult<()> {
+    let trace_storage = trace_cache.get_coset_evaluations(coset_idx)?;
+    let TracePolynomials {
+        variable_cols,
+        witness_cols,
+        multiplicity_cols,
+    } = trace_storage.as_polynomials();
+    let setup_storage = setup_cache.get_coset_evaluations(coset_idx)?;
+    let SetupPolynomials {
+        permutation_cols,
+        constant_cols,
+        table_cols,
+    } = setup_storage.as_polynomials();
+    let arguments_storage = arguments_cache.get_coset_evaluations(coset_idx)?;
+    let ArgumentsPolynomials {
+        z_polys,
+        partial_products,
+        lookup_a_polys,
+        lookup_b_polys,
+    } = arguments_storage.as_polynomials();
+    let z_poly = &z_polys[0];
 
     let l0 = compute_l0_over_coset(coset_idx, domain_size, used_lde_degree)?;
     assert_eq!(l0.storage.len(), domain_size);
-
-    mem::d2d(
-        argument_polys.z_poly.c0.storage.as_ref(),
-        &mut quotient.c0.storage.as_mut(),
-    )?;
-    mem::d2d(
-        argument_polys.z_poly.c1.storage.as_ref(),
-        &mut quotient.c1.storage.as_mut(),
-    )?;
+    mem::d2d(z_poly.as_single_slice(), quotient.as_single_slice_mut())?;
     quotient.sub_constant(&DExt::one()?)?;
     quotient.mul_assign_real(&l0)?;
     quotient.scale(&copy_permutation_challenge_z_at_one_equals_one.into())?;
 
     if specialized_gates.len() > 0 {
         generic_evaluate_constraints_by_coset(
-            &trace_polys,
-            &setup_polys,
+            &variable_cols,
+            &witness_cols,
+            &constant_cols,
             specialized_gates,
             selector_placement.clone(),
             domain_size,
@@ -68,8 +75,9 @@ where
     assert!(general_purpose_gates.len() > 0);
     if general_purpose_gates.len() > 1 {
         generic_evaluate_constraints_by_coset(
-            &trace_polys,
-            &setup_polys,
+            &variable_cols,
+            &witness_cols,
+            &constant_cols,
             general_purpose_gates,
             selector_placement.clone(),
             domain_size,
@@ -81,27 +89,16 @@ where
 
     assert_eq!(
         copy_permutation_challenges_partial_product_terms.len(),
-        argument_polys.partial_products.len() + 1
+        arguments_cache.layout.num_partial_products / 2 + 1
     );
 
     let coset_omegas = compute_omega_values_for_coset(coset_idx, domain_size, used_lde_degree)?;
 
-    // compute_quotient_for_partial_products_naive(
-    //     &trace_polys,
-    //     &setup_polys,
-    //     &argument_polys,
-    //     &coset_omegas,
-    //     num_cols_per_product,
-    //     beta.clone(),
-    //     gamma.clone(),
-    //     &non_residues_by_beta,
-    //     powers_of_alpha_for_copy_permutation.clone(),
-    //     quotient,
-    // )?;
     compute_quotient_for_partial_products(
-        &trace_polys,
-        &setup_polys,
-        &argument_polys,
+        &variable_cols,
+        &permutation_cols,
+        &z_poly,
+        &partial_products,
         &coset_omegas,
         num_cols_per_product,
         &beta,
@@ -117,9 +114,12 @@ where
         let columns_per_subargument = lookup_params.specialized_columns_per_subargument() as usize;
 
         compute_quotient_for_lookup_over_specialized_cols(
-            &trace_polys,
-            &setup_polys,
-            &argument_polys,
+            &variable_cols,
+            &multiplicity_cols,
+            &constant_cols,
+            &table_cols,
+            &lookup_a_polys,
+            &lookup_b_polys,
             lookup_params,
             lookup_beta.unwrap(),
             &powers_of_gamma_for_lookup,

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,4 @@
-use crate::cs::{materialize_permutation_cols_from_transformed_hints_into, GpuSetup};
+use crate::cs::{materialize_permutation_cols_from_indexes_into, GpuSetup};
 
 use super::*;
 use std::{path::Path, sync::Arc};
@@ -109,16 +109,16 @@ fn test_proof_comparison_for_poseidon_gate_with_private_witnesses() {
         let prover_config = init_proof_cfg();
 
         proving_cs.prove_from_precomputations::<GoldilocksExt2, DefaultTranscript, DefaultTreeHasher, NoPow>(
-                prover_config,
-                &setup_base,
-                &setup,
-                &setup_tree,
-                &vk,
-                &vars_hint,
-                &wits_hint,
-                (),
-                &worker,
-            )
+            prover_config,
+            &setup_base,
+            &setup,
+            &setup_tree,
+            &vk,
+            &vars_hint,
+            &wits_hint,
+            (),
+            &worker,
+        )
     };
     let actual_proof = actual_proof.into();
     compare_proofs(&expected_proof, &actual_proof);
@@ -158,7 +158,7 @@ fn init_or_synth_cs_with_poseidon2_and_private_witnesses<CFG: CSConfig, const DO
     // quick and dirty way of testing with private witnesses
     fn synthesize<CS: ConstraintSystem<F>>(cs: &mut CS) -> [Variable; 8] {
         use rand::{Rng, SeedableRng};
-        let mut rng = rand::rngs::StdRng::seed_from_u64(42 as u64);
+        let mut rng = rand::rngs::StdRng::seed_from_u64(42);
         type R = Poseidon2Goldilocks;
         let num_gates = 1 << 16;
         let mut prev_state = [cs.allocate_constant(F::ZERO); 12];
@@ -238,13 +238,15 @@ fn test_permutation_polys() {
     println!("Gpu setup is made");
 
     let mut actual_copy_permutation_polys =
-        GenericStorage::allocate(num_copy_permutation_polys, domain_size).unwrap();
+        GenericStorage::allocate(num_copy_permutation_polys, domain_size);
     let copy_permutation_polys_as_slice_view = actual_copy_permutation_polys.as_single_slice_mut();
     println!("GenericSetupStorage is allocated");
-
-    materialize_permutation_cols_from_transformed_hints_into(
+    let variable_indexes =
+        construct_indexes_from_hint(&gpu_setup.variables_hint, domain_size).unwrap();
+    materialize_permutation_cols_from_indexes_into(
         copy_permutation_polys_as_slice_view,
-        &gpu_setup.variables_hint,
+        &variable_indexes,
+        num_copy_permutation_polys,
         domain_size,
     )
     .unwrap();
@@ -257,7 +259,7 @@ fn test_permutation_polys() {
         .map(|p| P::vec_into_base_vec(p))
         .zip(
             actual_copy_permutation_polys
-                .into_poly_storage::<LagrangeBasis>()
+                .into_poly_storage()
                 .polynomials
                 .into_iter()
                 .map(|p| p.storage.into_inner())
@@ -298,16 +300,16 @@ fn test_setup_comparison() {
     let actual_setup = GenericSetupStorage::from_gpu_setup(&gpu_setup).unwrap();
 
     assert_eq!(
-        expected_setup.storage.inner.to_vec().unwrap(),
-        actual_setup.storage.inner.to_vec().unwrap(),
+        expected_setup.inner.to_vec().unwrap(),
+        actual_setup.inner.to_vec().unwrap(),
     );
 
     let expected_monomial = expected_setup.into_monomials().unwrap();
     let actual_monomial = actual_setup.into_monomials().unwrap();
 
     assert_eq!(
-        expected_monomial.storage.inner.to_vec().unwrap(),
-        actual_monomial.storage.inner.to_vec().unwrap(),
+        expected_monomial.inner.to_vec().unwrap(),
+        actual_monomial.inner.to_vec().unwrap(),
     );
 }
 
@@ -318,6 +320,87 @@ fn clone_reference_tree(
         cap_size: input.cap_size,
         leaf_hashes: input.leaf_hashes.clone(),
         node_hashes_enumerated_from_leafs: input.node_hashes_enumerated_from_leafs.clone(),
+    }
+}
+
+#[cfg(feature = "allocator_stats")]
+#[serial]
+#[test]
+#[ignore]
+fn test_dry_runs() {
+    let (setup_cs, finalization_hint) = init_or_synth_cs_for_sha256::<DevCSConfig, true>(None);
+
+    let worker = Worker::new();
+    let prover_config = init_proof_cfg();
+    let (setup_base, _setup, vk, setup_tree, vars_hint, wits_hint) = setup_cs.get_full_setup(
+        &worker,
+        prover_config.fri_lde_factor,
+        prover_config.merkle_tree_cap_size,
+    );
+    let domain_size = setup_cs.max_trace_len;
+    let _ctx = ProverContext::dev(domain_size).expect("init gpu prover context");
+    let gpu_setup = GpuSetup::<Global>::from_setup_and_hints(
+        setup_base.clone(),
+        clone_reference_tree(&setup_tree),
+        vars_hint.clone(),
+        wits_hint.clone(),
+        &worker,
+    )
+    .unwrap();
+
+    assert!(domain_size.is_power_of_two());
+    let (mut proving_cs, _) =
+        init_or_synth_cs_for_sha256::<ProvingCSConfig, true>(finalization_hint.as_ref());
+    let witness = proving_cs.materialize_witness_vec();
+    let (reusable_cs, _) =
+        init_or_synth_cs_for_sha256::<ProvingCSConfig, false>(finalization_hint.as_ref());
+    let candidates =
+        CacheStrategy::get_strategy_candidates(&reusable_cs, &prover_config, &gpu_setup);
+    for (_, strategy) in candidates.iter().copied() {
+        let proof = || {
+            let _ = crate::prover::gpu_prove_from_external_witness_data_with_cache_strategy::<
+                _,
+                DefaultTranscript,
+                DefaultTreeHasher,
+                NoPow,
+                Global,
+            >(
+                &reusable_cs,
+                &witness,
+                prover_config.clone(),
+                &gpu_setup,
+                &vk,
+                (),
+                &worker,
+                strategy,
+            )
+            .expect("gpu proof");
+        };
+        dry_run_start();
+        proof();
+        dry_run_stop().unwrap();
+        let dry = _alloc()
+            .stats
+            .lock()
+            .unwrap()
+            .allocations_at_maximum_block_count_at_maximum_tail_index
+            .clone();
+        let dry_tail_index = dry.tail_index();
+        _setup_cache_reset();
+        _alloc().stats.lock().unwrap().reset();
+        assert_eq!(_alloc().stats.lock().unwrap().allocations.tail_index(), 0);
+        proof();
+        let wet = _alloc()
+            .stats
+            .lock()
+            .unwrap()
+            .allocations_at_maximum_block_count_at_maximum_tail_index
+            .clone();
+        let wet_tail_index = wet.tail_index();
+        _setup_cache_reset();
+        _alloc().stats.lock().unwrap().reset();
+        assert_eq!(_alloc().stats.lock().unwrap().allocations.tail_index(), 0);
+        assert_eq!(dry_tail_index, wet_tail_index);
     }
 }
 
@@ -336,7 +419,6 @@ fn test_proof_comparison_for_sha256() {
     );
     let domain_size = setup_cs.max_trace_len;
     let _ctx = ProverContext::dev(domain_size).expect("init gpu prover context");
-    // let ctx = ProverContext::create_8gb_dev(domain_size).expect("gpu prover context");
     let gpu_setup = GpuSetup::<Global>::from_setup_and_hints(
         setup_base.clone(),
         clone_reference_tree(&setup_tree),
@@ -380,16 +462,16 @@ fn test_proof_comparison_for_sha256() {
         let prover_config = init_proof_cfg();
 
         proving_cs.prove_from_precomputations::<GoldilocksExt2, DefaultTranscript, DefaultTreeHasher, NoPow>(
-                prover_config,
-                &setup_base,
-                &setup,
-                &setup_tree,
-                &vk,
-                &vars_hint,
-                &wits_hint,
-                (),
-                &worker,
-            )
+            prover_config,
+            &setup_base,
+            &setup,
+            &setup_tree,
+            &vk,
+            &vars_hint,
+            &wits_hint,
+            (),
+            &worker,
+        )
     };
     let actual_proof = actual_proof.into();
     compare_proofs(&expected_proof, &actual_proof);
@@ -406,7 +488,7 @@ fn init_or_synth_cs_for_sha256<CFG: CSConfig, const DO_SYNTH: bool>(
     // let len = 2 * (1 << 10);
     let len = 2 * (1 << 2);
     use rand::{Rng, SeedableRng};
-    let mut rng = rand::rngs::StdRng::seed_from_u64(42 as u64);
+    let mut rng = rand::rngs::StdRng::seed_from_u64(42);
 
     let mut input = vec![];
     for _ in 0..len {
@@ -498,7 +580,7 @@ fn init_or_synth_cs_for_sha256<CFG: CSConfig, const DO_SYNTH: bool>(
         //     cs.place_variable(var.get_variable(), next_available_row, column);
         //     cs.set_public(column, next_available_row);
         // }
-        let output = hex::encode(&(output.witness_hook(&*cs))().unwrap());
+        let output = hex::encode(&output.witness_hook(&*cs)().unwrap());
         let reference_output = hex::encode(reference_output.as_slice());
         assert_eq!(output, reference_output);
     }
@@ -710,6 +792,7 @@ mod zksync {
         aux_definitions::witness_oracle::VmWitnessOracle,
         circuit_definitions::base_layer::ZkSyncBaseLayerCircuit, ZkSyncDefaultRoundFunction,
     };
+    use cudart_sys::CudaError;
 
     pub type ZksyncProof = Proof<F, DefaultTreeHasher, GoldilocksExt2>;
 
@@ -822,26 +905,24 @@ mod zksync {
         let actual_setup = GenericSetupStorage::from_gpu_setup(&gpu_setup).unwrap();
 
         assert_eq!(
-            expected_setup.storage.inner.to_vec().unwrap(),
-            actual_setup.storage.inner.to_vec().unwrap(),
+            expected_setup.inner.to_vec().unwrap(),
+            actual_setup.inner.to_vec().unwrap(),
         );
 
         let expected_monomial = expected_setup.into_monomials().unwrap();
         let actual_monomial = actual_setup.into_monomials().unwrap();
 
         assert_eq!(
-            expected_monomial.storage.inner.to_vec().unwrap(),
-            actual_monomial.storage.inner.to_vec().unwrap(),
+            expected_monomial.inner.to_vec().unwrap(),
+            actual_monomial.inner.to_vec().unwrap(),
         );
     }
 
-    fn compare_proofs_for_all_zksync_circuits(limit_mem: bool) -> CudaResult<()> {
+    #[serial]
+    #[test]
+    fn compare_proofs_for_all_zksync_circuits() -> CudaResult<()> {
         let worker = &Worker::new();
-        let _ctx = if limit_mem {
-            ProverContext::create_limited().expect("gpu prover context")
-        } else {
-            ProverContext::create().expect("gpu prover context")
-        };
+        let _ctx = ProverContext::create().expect("gpu prover context");
 
         for main_dir in ["base", "leaf", "node"] {
             let data_dir = format!("./test_data/{}", main_dir);
@@ -855,12 +936,12 @@ mod zksync {
                 let reference_proof_path =
                     format!("{}/{}.cpu.proof", data_dir, circuit.numeric_circuit_type());
 
-                let reference_proof_path = std::path::Path::new(&reference_proof_path);
+                let reference_proof_path = Path::new(&reference_proof_path);
 
                 let gpu_proof_path =
                     format!("{}/{}.gpu.proof", data_dir, circuit.numeric_circuit_type());
 
-                let gpu_proof_path = std::path::Path::new(&gpu_proof_path);
+                let gpu_proof_path = Path::new(&gpu_proof_path);
 
                 if reference_proof_path.exists() && gpu_proof_path.exists() {
                     continue;
@@ -898,7 +979,7 @@ mod zksync {
                     let witness = proving_cs.materialize_witness_vec();
                     let reusable_cs =
                         init_cs_for_external_proving(circuit.clone(), &finalization_hint);
-                    gpu_prove_from_external_witness_data::<
+                    let proof = gpu_prove_from_external_witness_data::<
                         _,
                         DefaultTranscript,
                         DefaultTreeHasher,
@@ -913,7 +994,8 @@ mod zksync {
                         (),
                         worker,
                     )
-                    .expect("gpu proof")
+                    .expect("gpu proof");
+                    proof
                 };
 
                 let reference_proof_file = std::fs::File::open(reference_proof_path).unwrap();
@@ -933,19 +1015,6 @@ mod zksync {
     #[serial]
     #[test]
     #[ignore]
-    fn compare_proofs_for_all_zksync_circuits_limit_mem() -> CudaResult<()> {
-        compare_proofs_for_all_zksync_circuits(true)
-    }
-
-    #[serial]
-    #[test]
-    fn compare_proofs_for_all_zksync_circuits_all_mem() -> CudaResult<()> {
-        compare_proofs_for_all_zksync_circuits(false)
-    }
-
-    #[serial]
-    #[test]
-    #[ignore]
     fn generate_reference_proofs_for_all_zksync_circuits() {
         let worker = &Worker::new();
 
@@ -955,7 +1024,7 @@ mod zksync {
             let circuits = scan_directory_for_circuits(&data_dir);
 
             for circuit in circuits.into_iter() {
-                if std::path::Path::new(&format!(
+                if Path::new(&format!(
                     "{}/{}.cpu.proof",
                     data_dir,
                     circuit.numeric_circuit_type(),
@@ -1015,15 +1084,12 @@ mod zksync {
         }
     }
 
-    fn compare_proofs_with_external_synthesis_for_single_zksync_circuit_in_single_shot(
-        limit_mem: bool,
-    ) {
+    #[serial]
+    #[test]
+    #[ignore]
+    fn compare_proofs_for_single_zksync_circuit() {
         let circuit = get_circuit_from_env();
-        let _ctx = if limit_mem {
-            ProverContext::create_limited().expect("gpu prover context")
-        } else {
-            ProverContext::create().expect("gpu prover context")
-        };
+        let _ctx = ProverContext::create().expect("gpu prover context");
 
         println!(
             "{} {}",
@@ -1049,7 +1115,6 @@ mod zksync {
 
         let mut proving_cs = synth_circuit_for_proving(circuit.clone(), &finalization_hint);
 
-        println!("gpu proving");
         let gpu_setup = GpuSetup::<Global>::from_setup_and_hints(
             setup_base.clone(),
             clone_reference_tree(&setup_tree),
@@ -1058,6 +1123,8 @@ mod zksync {
             &worker,
         )
         .expect("gpu setup");
+
+        println!("gpu proving");
         let gpu_proof = {
             let witness = proving_cs.materialize_witness_vec();
             let reusable_cs = init_cs_for_external_proving(circuit.clone(), &finalization_hint);
@@ -1078,6 +1145,7 @@ mod zksync {
             )
             .expect("gpu proof")
         };
+
         println!("cpu proving");
         let reference_proof = {
             // we can't clone assembly lets synth it again
@@ -1105,15 +1173,91 @@ mod zksync {
     #[serial]
     #[test]
     #[ignore]
-    fn compare_proofs_with_external_synthesis_for_single_zksync_circuit_in_single_shot_all_mem() {
-        compare_proofs_with_external_synthesis_for_single_zksync_circuit_in_single_shot(false);
-    }
-
-    #[serial]
-    #[test]
-    #[ignore]
-    fn compare_proofs_with_external_synthesis_for_single_zksync_circuit_in_single_shot_limit_mem() {
-        compare_proofs_with_external_synthesis_for_single_zksync_circuit_in_single_shot(true);
+    fn benchmark_single_circuit() {
+        let circuit = get_circuit_from_env();
+        println!(
+            "{} {}",
+            circuit.numeric_circuit_type(),
+            circuit.short_description()
+        );
+        let worker = &Worker::new();
+        let (setup_cs, finalization_hint) = synth_circuit_for_setup(circuit.clone());
+        let proof_cfg = circuit.proof_config();
+        let (setup_base, _setup, vk, setup_tree, vars_hint, wits_hint) = setup_cs.get_full_setup(
+            worker,
+            proof_cfg.fri_lde_factor,
+            proof_cfg.merkle_tree_cap_size,
+        );
+        let mut proving_cs = synth_circuit_for_proving(circuit.clone(), &finalization_hint);
+        let witness = proving_cs.materialize_witness_vec();
+        let reusable_cs = init_cs_for_external_proving(circuit.clone(), &finalization_hint);
+        let gpu_setup = {
+            let _ctx = ProverContext::create().expect("gpu prover context");
+            GpuSetup::<Global>::from_setup_and_hints(
+                setup_base.clone(),
+                clone_reference_tree(&setup_tree),
+                vars_hint.clone(),
+                wits_hint.clone(),
+                &worker,
+            )
+            .expect("gpu setup")
+        };
+        let proof_fn = || {
+            let _ = gpu_prove_from_external_witness_data::<
+                _,
+                DefaultTranscript,
+                DefaultTreeHasher,
+                NoPow,
+                Global,
+            >(
+                &reusable_cs,
+                &witness,
+                proof_cfg.clone(),
+                &gpu_setup,
+                &vk,
+                (),
+                worker,
+            )
+            .expect("gpu proof");
+        };
+        loop {
+            for i in 0..40 {
+                let num_blocks = 2560 - i * 64;
+                println!("num_blocks = {num_blocks}");
+                let ctx = ProverContext::create_limited(num_blocks).expect("gpu prover context");
+                println!("warmup");
+                proof_fn();
+                _setup_cache_reset();
+                let strategy =
+                    CacheStrategy::get::<_, DefaultTranscript, DefaultTreeHasher, NoPow, Global>(
+                        &reusable_cs,
+                        &witness,
+                        proof_cfg.clone(),
+                        &gpu_setup,
+                        &vk,
+                        (),
+                        worker,
+                    );
+                let strategy = match strategy {
+                    Ok(s) => s,
+                    Err(CudaError::ErrorMemoryAllocation) => {
+                        println!("no cache strategy for {num_blocks}  found");
+                        return;
+                    }
+                    Err(e) => panic!("unexpected error: {e}"),
+                };
+                println!("strategy: {:?}", strategy);
+                println!("first run");
+                let start = std::time::Instant::now();
+                proof_fn();
+                println!("◆ total: {:?}", start.elapsed());
+                println!("second run");
+                let start = std::time::Instant::now();
+                proof_fn();
+                println!("◆ total: {:?}", start.elapsed());
+                drop(ctx);
+            }
+        }
     }
 
     #[serial]


### PR DESCRIPTION
# What ❔

This PR implements caching logic with self-adjustable caching configurations for setup/trace/arguments polynomials.

## Why ❔

Adjustable ratios between caching and re-computation of various polynomial groups allow for variable tradeoff between memory usage and performance.
This PR implements a cost model and a logic for determining the optimal caching strategy for the amount of memory that is available.
The result is that when the amount of available GPU memory is  ~21 GB or more, full performance can be extracted and on the other end of the spectrum the prover can run with less than 6 GB of GPU RAM although with significantly lower performance that the full performance.

Here are results of a benchmarks done on a L4 GPU for the MainVM base layer circuit to show the tradeoff of performance vs memory usage. Keep in mind that the values for memory usage are numbers of memory reserved for various data structures used by the prover, there are additional memory requirements coming from the OS, GPU driver or other processes, these can differ significantly based on a particular GPU model and the OS. For example for a L4 running under linux, the observed additional allocated memory amounted to ~0,75 GB.

| VRAM used (GB)|First run (s)|Subsequent runs (s)|
|-:|-:|-:|
|20.0|1.976|1.304|
|19.5|1.999|1.339|
|19.0|2.038|1.380|
|18.5|2.133|1.467|
|14.5|2.012|1.534|
|13.5|2.060|1.570|
|13.0|2.099|1.614|
|12.5|2.116|1.653|
|12.0|2.151|1.667|
|11.5|2.185|1.701|
|11.0|2.221|1.747|
|10.5|2.278|1.800|
|10.0|2.310|1.827|
|9.5|2.363|1.883|
|9.0|2.442|1.964|
|8.5|2.492|2.017|
|8.0|2.580|2.104|
|7.5|2.721|2.243|
|7.0|2.990|2.485|
|6.5|3.022|2.523|
|6.0|3.400|2.892|
|5.5|3.480|2.980|

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and linted with `cargo check`.
