### PR TITLE
streamline static variables and extend the context

### DIFF
--- a/src/static_allocator/host.rs
+++ b/src/static_allocator/host.rs
@@ -130,6 +130,7 @@ impl StaticHostAllocator {
             .is_ok();
     }
 
+    #[allow(dead_code)]
     pub fn free(self) -> CudaResult<()> {
         println!("freeing static host allocation");
         assert_eq!(Arc::weak_count(&self.memory), 0);
@@ -208,6 +209,7 @@ impl SmallStaticHostAllocator {
         Ok(Self { inner })
     }
 
+    #[allow(dead_code)]
     pub fn free(self) -> CudaResult<()> {
         self.inner.free()
     }


### PR DESCRIPTION
# What ❔

This PR refactors various static variables into a single structure and adds auxiliary streams, events, l2 cache size and compute capability version into it.

## Why ❔

The growing number of static variables became unwieldy and new variables needed to be added, therefore a refactoring was warranted. Additional field intended for use by improvements down the line were needed.

## Checklist
- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted via `cargo fmt` and linted with `cargo check`.
