### PR TITLE
Run warmup with chosen strategy in benchmark_single_circuit

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -1225,8 +1225,8 @@ mod zksync {
                 let num_blocks = 2560 - i * 64;
                 println!("num_blocks = {num_blocks}");
                 let ctx = ProverContext::create_limited(num_blocks).expect("gpu prover context");
-                println!("warmup");
-                proof_fn();
+                // technically not needed because CacheStrategy::get calls it internally,
+                // but nice for peace of mind
                 _setup_cache_reset();
                 let strategy =
                     CacheStrategy::get::<_, DefaultTranscript, DefaultTreeHasher, NoPow, Global>(
@@ -1238,6 +1238,9 @@ mod zksync {
                         (),
                         worker,
                     );
+                // technically not needed because CacheStrategy::get calls it internally,
+                // but nice for peace of mind
+                _setup_cache_reset();
                 let strategy = match strategy {
                     Ok(s) => s,
                     Err(CudaError::ErrorMemoryAllocation) => {
@@ -1247,6 +1250,9 @@ mod zksync {
                     Err(e) => panic!("unexpected error: {e}"),
                 };
                 println!("strategy: {:?}", strategy);
+                println!("warmup with determined strategy");
+                proof_fn();
+                _setup_cache_reset();
                 println!("first run");
                 let start = std::time::Instant::now();
                 proof_fn();


### PR DESCRIPTION
# What ❔

In current code, each `benchmark_single_circuit` iteration does a warmup run _before_ choosing the strategy that fits the iteration's memory limit. This caused a genuine 
```thread 'test::zksync::benchmark_single_circuit' panicked at 'gpu proof: ErrorMemoryAllocation', src/test.rs:1221:14```
panic (from a warmup run) when I ran it.

## Why ❔

With this diff, `benchmark_single_circuit` runs end to end without panics.

I reread when and how the setup cache is created, as well as `_setup_cache_reset()`'s other points of use, to decide when the test should call `_setup_cache_reset()`. But I'm obviously not as familiar as you, so please double check that I'm calling it in the right places :P

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [ ] Tests for the changes have been added / updated.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `zk fmt` and `zk lint`.
