### PR TITLE
implement h2d transfers using pinned memory

### DIFF
--- a/src/primitives/cs_helpers.rs
+++ b/src/primitives/cs_helpers.rs
@@ -5,9 +5,7 @@ use boojum_cuda::{
     device_structures::{DeviceMatrix, DeviceMatrixMut},
     extension_field::VectorizedExtensionField,
 };
-use cudart::device::device_get_attribute;
 use cudart::stream::CudaStreamWaitEventFlags;
-use cudart_sys::CudaDeviceAttr;
 use std::mem::size_of;
 
 #[allow(dead_code)]

--- a/src/primitives/mem.rs
+++ b/src/primitives/mem.rs
@@ -1,11 +1,84 @@
 use super::*;
+use boojum::worker::Worker;
+use cudart::execution::{launch_host_fn, HostFn};
 pub use cudart::memory::memory_copy_async;
+use cudart::stream::CudaStreamWaitEventFlags;
+use std::intrinsics::copy_nonoverlapping;
+use std::mem::size_of;
+use std::ops::DerefMut;
+use std::slice;
 
 pub fn h2d<T>(host: &[T], device: &mut [T]) -> CudaResult<()> {
     assert!(!host.is_empty());
     assert_eq!(host.len(), device.len());
     if_not_dry_run! {
         memory_copy_async(&mut device[..], host, get_h2d_stream())
+    }
+}
+
+pub fn h2d_buffered<'a, T: Send + Sync>(
+    host: &'a [T],
+    device: &'a mut [T],
+    chunk_size: usize,
+    worker: &'a Worker,
+) -> CudaResult<Vec<HostFn<'a>>> {
+    assert!(!host.is_empty());
+    assert_eq!(host.len(), device.len());
+    assert_ne!(chunk_size, 0);
+    if is_dry_run()? {
+        return Ok(vec![]);
+    } else {
+        const STREAMS_COUNT: usize = 2;
+        assert!(STREAMS_COUNT <= NUM_AUX_STREAMS_AND_EVENTS);
+        assert!(chunk_size * STREAMS_COUNT * size_of::<T>() <= AUX_H2D_BUFFER_SIZE);
+        let events = &_aux_events()[0..STREAMS_COUNT];
+        let streams = &_aux_streams()[0..STREAMS_COUNT];
+        let buffer: &mut [T] = unsafe { std::mem::transmute(_aux_h2d_buffer().deref_mut()) };
+        let main_stream = get_h2d_stream();
+        let copy = |src: &[T], dst: &mut [T]| {
+            worker.scope(src.len(), |scope, chunk_size| {
+                for (src_chunk, dst_chunk) in src.chunks(chunk_size).zip(dst.chunks_mut(chunk_size))
+                {
+                    scope.spawn(|_| unsafe {
+                        copy_nonoverlapping(
+                            src_chunk.as_ptr(),
+                            dst_chunk.as_mut_ptr(),
+                            src_chunk.len(),
+                        )
+                    })
+                }
+            });
+        };
+        events[0].record(main_stream)?;
+        for stream in streams.iter() {
+            stream.wait_event(&events[0], CudaStreamWaitEventFlags::DEFAULT)?;
+        }
+        let mut pending_callbacks = vec![];
+        for (i, (src, dst)) in host
+            .chunks(chunk_size)
+            .zip(device.chunks_mut(chunk_size))
+            .enumerate()
+        {
+            let idx = i % STREAMS_COUNT;
+            let stream = &streams[idx];
+            let buffer_offset = idx * chunk_size;
+            let buffer = &buffer[buffer_offset..buffer_offset + src.len()];
+            let callback = HostFn::new(move || {
+                let dst =
+                    unsafe { slice::from_raw_parts_mut(buffer.as_ptr() as *mut T, buffer.len()) };
+                copy(src, dst);
+            });
+            launch_host_fn(stream, &callback)?;
+            pending_callbacks.push(callback);
+            let dst = unsafe { DeviceSlice::from_mut_slice(dst) };
+            memory_copy_async(dst, buffer, stream)?;
+        }
+
+        for (event, stream) in events.iter().zip(streams.iter()) {
+            event.record(stream)?;
+            main_stream.wait_event(event, CudaStreamWaitEventFlags::DEFAULT)?;
+        }
+        Ok(pending_callbacks)
     }
 }
 

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -112,6 +112,7 @@ pub(crate) fn gpu_prove_from_external_witness_data_with_cache_strategy<
             setup,
             fri_lde_degree,
             used_lde_degree,
+            worker,
         )?;
         if !is_dry_run()? {
             println!("◆ setup: {:?}", timer.elapsed());


### PR DESCRIPTION
# What ❔

This PR implements h2d transfers using pinned memory buffer.

## Why ❔

Pinned memory transfers are faster and can execute asynchronously.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and linted via `cargo check`.
