### PR TITLE
implement GpuProofConfig abstraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.48",
+ "syn 2.0.49",
  "which",
 ]
 
@@ -262,7 +262,7 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 [[package]]
 name = "boojum"
 version = "0.2.0"
-source = "git+https://github.com/matter-labs/era-boojum?branch=main#03888f0fbf810a18e98d010dd11891fe32097352"
+source = "git+https://github.com/matter-labs/era-boojum?branch=main#a4bb73f4164c5bae4087fef43c0052e5bb556a06"
 dependencies = [
  "arrayvec 0.7.4",
  "bincode",
@@ -354,7 +354,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "circuit_definitions"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness?branch=v1.4.1#5a92455120190e9af10e2b5d4a7e6a9f7a246db5"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness?branch=v1.4.1#f16b40eb4662768b5e29030b240420abc60d115b"
 dependencies = [
  "crossbeam 0.8.4",
  "derivative",
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "cs_derive"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-boojum?branch=main#03888f0fbf810a18e98d010dd11891fe32097352"
+source = "git+https://github.com/matter-labs/era-boojum?branch=main#a4bb73f4164c5bae4087fef43c0052e5bb556a06"
 dependencies = [
  "proc-macro-error",
  "proc-macro2 1.0.78",
@@ -1368,7 +1368,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2 1.0.78",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1508,7 +1508,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2 1.0.78",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1859,7 +1859,7 @@ checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1895,7 +1895,7 @@ checksum = "b93fb4adc70021ac1b47f7d45e8cc4169baaa7ea58483bc5b721d19a26202212"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "shivini"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "blake2 0.10.6",
@@ -2069,9 +2069,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496"
 dependencies = [
  "proc-macro2 1.0.78",
  "quote 1.0.35",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shivini"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/gpu_proof_config.rs
+++ b/src/gpu_proof_config.rs
@@ -1,0 +1,166 @@
+use crate::synthesis_utils::CircuitWrapper;
+use boojum::config::ProvingCSConfig;
+use boojum::cs::implementations::reference_cs::CSReferenceAssembly;
+use boojum::cs::implementations::verifier::{
+    TypeErasedGateEvaluationVerificationFunction, Verifier,
+};
+use boojum::cs::traits::evaluator::{
+    GatePlacementType, PerChunkOffset, TypeErasedGateEvaluationFunction,
+};
+use boojum::cs::traits::gate::GatePlacementStrategy;
+use boojum::field::goldilocks::{GoldilocksExt2, GoldilocksField};
+use boojum::field::traits::field_like::PrimeFieldLikeVectorized;
+use boojum::field::FieldExtension;
+use circuit_definitions::aux_definitions::witness_oracle::VmWitnessOracle;
+use circuit_definitions::circuit_definitions::base_layer::ZkSyncBaseLayerCircuit;
+use circuit_definitions::circuit_definitions::recursion_layer::ZkSyncRecursiveLayerCircuit;
+use circuit_definitions::ZkSyncDefaultRoundFunction;
+use std::any::TypeId;
+use std::collections::HashMap;
+
+type F = GoldilocksField;
+type EXT = GoldilocksExt2;
+type BaseLayerCircuit = ZkSyncBaseLayerCircuit<F, VmWitnessOracle<F>, ZkSyncDefaultRoundFunction>;
+
+pub(crate) struct EvaluatorData {
+    pub debug_name: String,
+    pub unique_name: String,
+    pub max_constraint_degree: usize,
+    pub num_quotient_terms: usize,
+    pub total_quotient_terms_over_all_repetitions: usize,
+    pub num_repetitions_on_row: usize,
+    pub placement_type: GatePlacementType,
+}
+
+impl<P: PrimeFieldLikeVectorized<Base = F>> From<&TypeErasedGateEvaluationFunction<F, P>>
+    for EvaluatorData
+{
+    fn from(value: &TypeErasedGateEvaluationFunction<F, P>) -> Self {
+        let debug_name = value.debug_name.clone();
+        let unique_name = value.unique_name.clone();
+        let max_constraint_degree = value.max_constraint_degree;
+        let num_quotient_terms = value.num_quotient_terms;
+        let total_quotient_terms_over_all_repetitions =
+            value.total_quotient_terms_over_all_repetitions;
+        let num_repetitions_on_row = value.num_repetitions_on_row;
+        let placement_type = value.placement_type;
+        Self {
+            debug_name,
+            unique_name,
+            max_constraint_degree,
+            num_quotient_terms,
+            total_quotient_terms_over_all_repetitions,
+            num_repetitions_on_row,
+            placement_type,
+        }
+    }
+}
+
+impl<EXT: FieldExtension<2, BaseField = F>>
+    From<&TypeErasedGateEvaluationVerificationFunction<F, EXT>> for EvaluatorData
+{
+    fn from(value: &TypeErasedGateEvaluationVerificationFunction<F, EXT>) -> Self {
+        let debug_name = value.debug_name.clone();
+        let unique_name = value.unique_name.clone();
+        let max_constraint_degree = value.max_constraint_degree;
+        let num_quotient_terms = value.num_quotient_terms;
+        let total_quotient_terms_over_all_repetitions =
+            value.total_quotient_terms_over_all_repetitions;
+        let num_repetitions_on_row = value.num_repetitions_on_row;
+        let placement_type = value.placement_type;
+        Self {
+            debug_name,
+            unique_name,
+            max_constraint_degree,
+            num_quotient_terms,
+            total_quotient_terms_over_all_repetitions,
+            num_repetitions_on_row,
+            placement_type,
+        }
+    }
+}
+
+pub struct GpuProofConfig {
+    pub(crate) gate_type_ids_for_specialized_columns: Vec<TypeId>,
+    pub(crate) evaluators_over_specialized_columns: Vec<EvaluatorData>,
+    pub(crate) offsets_for_specialized_evaluators: Vec<(PerChunkOffset, PerChunkOffset, usize)>,
+    pub(crate) evaluators_over_general_purpose_columns: Vec<EvaluatorData>,
+    pub(crate) placement_strategies: HashMap<TypeId, GatePlacementStrategy>,
+}
+
+impl GpuProofConfig {
+    pub fn from_assembly<P: PrimeFieldLikeVectorized<Base = F>>(
+        cs: &CSReferenceAssembly<F, P, ProvingCSConfig>,
+    ) -> Self {
+        let evaluation_data_over_specialized_columns = &cs.evaluation_data_over_specialized_columns;
+        let gate_type_ids_for_specialized_columns = evaluation_data_over_specialized_columns
+            .gate_type_ids_for_specialized_columns
+            .clone();
+        let evaluators_over_specialized_columns = evaluation_data_over_specialized_columns
+            .evaluators_over_specialized_columns
+            .iter()
+            .map(|x| x.into())
+            .collect();
+        let evaluators_over_general_purpose_columns = cs
+            .evaluation_data_over_general_purpose_columns
+            .evaluators_over_general_purpose_columns
+            .iter()
+            .map(|x| x.into())
+            .collect();
+        let offsets_for_specialized_evaluators = evaluation_data_over_specialized_columns
+            .offsets_for_specialized_evaluators
+            .clone();
+        let placement_strategies = cs.placement_strategies.clone();
+        Self {
+            gate_type_ids_for_specialized_columns,
+            evaluators_over_specialized_columns,
+            offsets_for_specialized_evaluators,
+            evaluators_over_general_purpose_columns,
+            placement_strategies,
+        }
+    }
+
+    pub fn from_verifier(verifier: &Verifier<F, EXT>) -> Self {
+        let gate_type_ids_for_specialized_columns =
+            verifier.gate_type_ids_for_specialized_columns.clone();
+        let evaluators_over_specialized_columns = verifier
+            .evaluators_over_specialized_columns
+            .iter()
+            .map(|x| x.into())
+            .collect();
+        let offsets_for_specialized_evaluators =
+            verifier.offsets_for_specialized_evaluators.clone();
+        let evaluators_over_general_purpose_columns = verifier
+            .evaluators_over_general_purpose_columns
+            .iter()
+            .map(|x| x.into())
+            .collect();
+        let placement_strategies = verifier.placement_strategies.clone();
+        Self {
+            gate_type_ids_for_specialized_columns,
+            evaluators_over_specialized_columns,
+            offsets_for_specialized_evaluators,
+            evaluators_over_general_purpose_columns,
+            placement_strategies,
+        }
+    }
+}
+
+impl From<CircuitWrapper> for GpuProofConfig {
+    fn from(value: CircuitWrapper) -> Self {
+        let verifier = value.get_verifier();
+        Self::from_verifier(&verifier)
+    }
+}
+
+impl From<BaseLayerCircuit> for GpuProofConfig {
+    fn from(value: BaseLayerCircuit) -> Self {
+        CircuitWrapper::Base(value).into()
+    }
+}
+
+impl From<ZkSyncRecursiveLayerCircuit> for GpuProofConfig {
+    fn from(value: ZkSyncRecursiveLayerCircuit) -> Self {
+        CircuitWrapper::Recursive(value).into()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ use copy_permutation::*;
 use data_structures::*;
 use lookup::*;
 use poly::*;
+pub mod gpu_proof_config;
 mod prover;
 mod quotient;
 #[cfg(feature = "zksync")]

--- a/src/synthesis_utils.rs
+++ b/src/synthesis_utils.rs
@@ -8,7 +8,7 @@ use boojum::cs::implementations::proof::Proof;
 use boojum::cs::implementations::prover::ProofConfig;
 use boojum::cs::implementations::reference_cs::{CSReferenceAssembly, CSReferenceImplementation};
 use boojum::cs::implementations::setup::FinalizationHintsForProver;
-use boojum::cs::implementations::verifier::VerificationKey;
+use boojum::cs::implementations::verifier::{VerificationKey, Verifier};
 use boojum::cs::traits::GoodAllocator;
 use boojum::cs::{CSGeometry, GateConfigurationHolder, StaticToolboxHolder};
 use boojum::field::goldilocks::{GoldilocksExt2, GoldilocksField};
@@ -123,7 +123,12 @@ impl CircuitWrapper {
         vk: &VerificationKey<F, DefaultTreeHasher>,
         proof: &ZksyncProof,
     ) -> bool {
-        let verifier = match self {
+        let verifier = self.get_verifier();
+        verifier.verify::<DefaultTreeHasher, DefaultTranscript, NoPow>((), vk, proof)
+    }
+
+    pub(crate) fn get_verifier(&self) -> Verifier<F, EXT> {
+        match self {
             CircuitWrapper::Base(_base_circuit) => {
                 use circuit_definitions::circuit_definitions::verifier_builder::dyn_verifier_builder_for_circuit_type;
 
@@ -137,9 +142,7 @@ impl CircuitWrapper {
                 let verifier_builder = recursive_circuit.into_dyn_verifier_builder();
                 verifier_builder.create_verifier()
             }
-        };
-
-        verifier.verify::<DefaultTreeHasher, DefaultTranscript, NoPow>((), vk, proof)
+        }
     }
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -43,6 +43,7 @@ use boojum::field::traits::field_like::PrimeFieldLikeVectorized;
 #[allow(dead_code)]
 pub type DefaultDevCS = CSReferenceAssembly<F, F, DevCSConfig>;
 type P = F;
+use crate::gpu_proof_config::GpuProofConfig;
 use serial_test::serial;
 
 #[serial]
@@ -80,14 +81,14 @@ fn test_proof_comparison_for_poseidon_gate_with_private_witnesses() {
             ProvingCSConfig,
             false,
         >(finalization_hint.as_ref());
+        let config = GpuProofConfig::from_assembly(&reusable_cs);
         let proof = gpu_prove_from_external_witness_data::<
-            _,
             DefaultTranscript,
             DefaultTreeHasher,
             NoPow,
             Global,
         >(
-            &reusable_cs,
+            &config,
             &witness,
             prover_config.clone(),
             &gpu_setup,
@@ -335,7 +336,7 @@ fn test_dry_runs() {
     let witness = proving_cs.witness.unwrap();
     let (reusable_cs, _) =
         init_or_synth_cs_for_sha256::<ProvingCSConfig, Global, false>(finalization_hint.as_ref());
-
+    let config = GpuProofConfig::from_assembly(&reusable_cs);
     let worker = Worker::new();
     let prover_config = init_proof_cfg();
     let (setup_base, _setup, vk, setup_tree, vars_hint, wits_hint) = setup_cs.get_full_setup(
@@ -355,18 +356,21 @@ fn test_dry_runs() {
     .unwrap();
 
     assert!(domain_size.is_power_of_two());
-    let candidates =
-        CacheStrategy::get_strategy_candidates(&reusable_cs, &prover_config, &gpu_setup);
+    let candidates = CacheStrategy::get_strategy_candidates(
+        &config,
+        &prover_config,
+        &gpu_setup,
+        &vk.fixed_parameters,
+    );
     for (_, strategy) in candidates.iter().copied() {
         let proof = || {
             let _ = crate::prover::gpu_prove_from_external_witness_data_with_cache_strategy::<
-                _,
                 DefaultTranscript,
                 DefaultTreeHasher,
                 NoPow,
                 Global,
             >(
-                &reusable_cs,
+                &config,
                 &witness,
                 prover_config.clone(),
                 &gpu_setup,
@@ -439,14 +443,15 @@ fn test_proof_comparison_for_sha256() {
         let (reusable_cs, _) = init_or_synth_cs_for_sha256::<ProvingCSConfig, Global, false>(
             finalization_hint.as_ref(),
         );
+        let config = GpuProofConfig::from_assembly(&reusable_cs);
+
         let proof = gpu_prove_from_external_witness_data::<
-            _,
             DefaultTranscript,
             DefaultTreeHasher,
             NoPow,
             Global,
         >(
-            &reusable_cs,
+            &config,
             &witness,
             prover_config.clone(),
             &gpu_setup,
@@ -802,8 +807,8 @@ mod zksync {
     const DEFAULT_CIRCUIT_INPUT: &str = "default.circuit";
 
     use crate::synthesis_utils::{
-        init_cs_for_external_proving, init_or_synthesize_assembly, synth_circuit_for_proving,
-        synth_circuit_for_setup, CircuitWrapper,
+        init_or_synthesize_assembly, synth_circuit_for_proving, synth_circuit_for_setup,
+        CircuitWrapper,
     };
 
     #[allow(dead_code)]
@@ -978,16 +983,14 @@ mod zksync {
                 let gpu_proof = {
                     let proving_cs = synth_circuit_for_proving(circuit.clone(), &finalization_hint);
                     let witness = proving_cs.witness.unwrap();
-                    let reusable_cs =
-                        init_cs_for_external_proving(circuit.clone(), &finalization_hint);
+                    let config = circuit.clone().into();
                     let proof = gpu_prove_from_external_witness_data::<
-                        _,
                         DefaultTranscript,
                         DefaultTreeHasher,
                         NoPow,
                         Global,
                     >(
-                        &reusable_cs,
+                        &config,
                         &witness,
                         proof_config.clone(),
                         &gpu_setup,
@@ -1128,15 +1131,14 @@ mod zksync {
         println!("gpu proving");
         let gpu_proof = {
             let witness = proving_cs.witness.as_ref().unwrap();
-            let reusable_cs = init_cs_for_external_proving(circuit.clone(), &finalization_hint);
+            let config = circuit.clone().into();
             gpu_prove_from_external_witness_data::<
-                _,
                 DefaultTranscript,
                 DefaultTreeHasher,
                 NoPow,
                 Global,
             >(
-                &reusable_cs,
+                &config,
                 &witness,
                 proof_cfg.clone(),
                 &gpu_setup,
@@ -1191,7 +1193,7 @@ mod zksync {
         );
         let proving_cs = synth_circuit_for_proving(circuit.clone(), &finalization_hint);
         let witness = proving_cs.witness.unwrap();
-        let reusable_cs = init_cs_for_external_proving(circuit.clone(), &finalization_hint);
+        let config = circuit.into();
         let gpu_setup = {
             let _ctx = ProverContext::create().expect("gpu prover context");
             GpuSetup::<Global>::from_setup_and_hints(
@@ -1205,13 +1207,12 @@ mod zksync {
         };
         let proof_fn = || {
             let _ = gpu_prove_from_external_witness_data::<
-                _,
                 DefaultTranscript,
                 DefaultTreeHasher,
                 NoPow,
                 Global,
             >(
-                &reusable_cs,
+                &config,
                 &witness,
                 proof_cfg.clone(),
                 &gpu_setup,
@@ -1230,8 +1231,8 @@ mod zksync {
                 // but nice for peace of mind
                 _setup_cache_reset();
                 let strategy =
-                    CacheStrategy::get::<_, DefaultTranscript, DefaultTreeHasher, NoPow, Global>(
-                        &reusable_cs,
+                    CacheStrategy::get::<DefaultTranscript, DefaultTreeHasher, NoPow, Global>(
+                        &config,
                         &witness,
                         proof_cfg.clone(),
                         &gpu_setup,
@@ -1290,6 +1291,7 @@ mod zksync {
         let (reusable_cs, _) = init_or_synth_cs_for_sha256::<ProvingCSConfig, Global, false>(
             finalization_hint.as_ref(),
         );
+        let config = GpuProofConfig::from_assembly(&reusable_cs);
         let mut gpu_setup = GpuSetup::<Global>::from_setup_and_hints(
             setup_base.clone(),
             clone_reference_tree(&setup_tree),
@@ -1301,13 +1303,12 @@ mod zksync {
         witness.public_inputs_locations = vec![(0, 0)];
         gpu_setup.variables_hint[0][0] = PACKED_PLACEHOLDER_BITMASK;
         let _ = gpu_prove_from_external_witness_data::<
-            _,
             DefaultTranscript,
             DefaultTreeHasher,
             NoPow,
             Global,
         >(
-            &reusable_cs,
+            &config,
             &witness,
             proof_config.clone(),
             &gpu_setup,


### PR DESCRIPTION
# What ❔

This PR implements a GpuProofConfig abstraction to remove a dependency on CSReferenceAssembly structure.

## Why ❔

Instantiation of the CSReferenceAssembly structure is expensive so we need to enable the possibility to supply the pieces of configuration the prover needs in an alternative way. This abstraction makes it possible to generate the information either from the CSReferenceAssembly structure or directly from a Circuit structure.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and linted via `cargo check`.
