### PR TITLE
chore: Dependency on new version of circuit_definitions without generics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,7 +351,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "circuit_definitions"
 version = "0.1.0"
-source = "git+https://github.com/matter-labs/era-zkevm_test_harness?branch=v1.4.2#d9da285c2e8a5fedddd2e9c2a893769ebd12a6ed"
+source = "git+https://github.com/matter-labs/era-zkevm_test_harness?branch=v1.4.2#b91defc8bccff6275db2416323a096dcb74a4dff"
 dependencies = [
  "crossbeam 0.8.4",
  "derivative",

--- a/src/gpu_proof_config.rs
+++ b/src/gpu_proof_config.rs
@@ -14,20 +14,15 @@ use boojum::cs::traits::gate::GatePlacementStrategy;
 use boojum::field::goldilocks::{GoldilocksExt2, GoldilocksField};
 use boojum::field::traits::field_like::PrimeFieldLikeVectorized;
 use boojum::field::FieldExtension;
-use circuit_definitions::aux_definitions::witness_oracle::VmWitnessOracle;
 use circuit_definitions::circuit_definitions::base_layer::ZkSyncBaseLayerCircuit;
 use circuit_definitions::circuit_definitions::recursion_layer::ZkSyncRecursiveLayerCircuit;
-use circuit_definitions::ZkSyncDefaultRoundFunction;
 use std::any::TypeId;
 use std::collections::HashMap;
 
 type F = GoldilocksField;
 type EXT = GoldilocksExt2;
-type BaseLayerCircuit = ZkSyncBaseLayerCircuit<F, VmWitnessOracle<F>, ZkSyncDefaultRoundFunction>;
-type EIP4844Circuit = circuit_definitions::circuit_definitions::eip4844::EIP4844Circuit<
-    F,
-    ZkSyncDefaultRoundFunction,
->;
+type BaseLayerCircuit = ZkSyncBaseLayerCircuit;
+type EIP4844Circuit = circuit_definitions::circuit_definitions::eip4844::EIP4844Circuit;
 
 pub(crate) struct EvaluatorData {
     pub debug_name: String,

--- a/src/synthesis_utils.rs
+++ b/src/synthesis_utils.rs
@@ -12,7 +12,6 @@ use boojum::cs::implementations::verifier::{VerificationKey, Verifier};
 use boojum::cs::traits::GoodAllocator;
 use boojum::cs::{CSGeometry, GateConfigurationHolder, StaticToolboxHolder};
 use boojum::field::goldilocks::{GoldilocksExt2, GoldilocksField};
-use circuit_definitions::aux_definitions::witness_oracle::VmWitnessOracle;
 use circuit_definitions::circuit_definitions::base_layer::ZkSyncBaseLayerCircuit;
 use circuit_definitions::circuit_definitions::recursion_layer::ZkSyncRecursiveLayerCircuit;
 use circuit_definitions::circuit_definitions::verifier_builder::EIP4844VerifierBuilder;
@@ -30,12 +29,9 @@ use crate::{DefaultTranscript, DefaultTreeHasher};
 type F = GoldilocksField;
 type P = F;
 #[allow(dead_code)]
-type BaseLayerCircuit = ZkSyncBaseLayerCircuit<F, VmWitnessOracle<F>, ZkSyncDefaultRoundFunction>;
+type BaseLayerCircuit = ZkSyncBaseLayerCircuit;
 #[allow(dead_code)]
-type EIP4844Circuit = circuit_definitions::circuit_definitions::eip4844::EIP4844Circuit<
-    F,
-    ZkSyncDefaultRoundFunction,
->;
+type EIP4844Circuit = circuit_definitions::circuit_definitions::eip4844::EIP4844Circuit;
 #[allow(dead_code)]
 type ZksyncProof = Proof<F, DefaultTreeHasher, GoldilocksExt2>;
 #[allow(dead_code)]
@@ -165,10 +161,7 @@ impl CircuitWrapper {
 
 pub(crate) fn get_verifier_for_base_layer_circuit(circuit: &BaseLayerCircuit) -> Verifier<F, EXT> {
     use circuit_definitions::circuit_definitions::verifier_builder::dyn_verifier_builder_for_circuit_type;
-    let verifier_builder =
-        dyn_verifier_builder_for_circuit_type::<F, EXT, ZkSyncDefaultRoundFunction>(
-            circuit.numeric_circuit_type(),
-        );
+    let verifier_builder = dyn_verifier_builder_for_circuit_type(circuit.numeric_circuit_type());
     verifier_builder.create_verifier()
 }
 
@@ -180,8 +173,7 @@ pub(crate) fn get_verifier_for_recursive_layer_circuit(
 }
 
 pub(crate) fn get_verifier_for_eip4844_circuit() -> Verifier<F, EXT> {
-    let verifier_builder =
-        EIP4844VerifierBuilder::<F, ZkSyncDefaultRoundFunction>::dyn_verifier_builder();
+    let verifier_builder = EIP4844VerifierBuilder::dyn_verifier_builder();
     verifier_builder.create_verifier()
 }
 
@@ -210,7 +202,7 @@ pub(crate) fn synth_circuit_for_proving(
 
 // called by zksync-era
 pub fn init_base_layer_cs_for_repeated_proving(
-    circuit: ZkSyncBaseLayerCircuit<F, VmWitnessOracle<F>, ZkSyncDefaultRoundFunction>,
+    circuit: ZkSyncBaseLayerCircuit,
     hint: &FinalizationHintsForProver,
 ) -> CSReferenceAssembly<F, F, ProvingCSConfig> {
     init_cs_for_external_proving(CircuitWrapper::Base(circuit), hint)

--- a/src/test.rs
+++ b/src/test.rs
@@ -795,10 +795,7 @@ mod zksync {
 
     use crate::cs::PACKED_PLACEHOLDER_BITMASK;
     use boojum::cs::implementations::fast_serialization::MemcopySerializable;
-    use circuit_definitions::{
-        aux_definitions::witness_oracle::VmWitnessOracle,
-        circuit_definitions::base_layer::ZkSyncBaseLayerCircuit, ZkSyncDefaultRoundFunction,
-    };
+    use circuit_definitions::circuit_definitions::base_layer::ZkSyncBaseLayerCircuit;
     use cudart_sys::CudaError;
 
     pub type ZksyncProof = Proof<F, DefaultTreeHasher, GoldilocksExt2>;
@@ -812,8 +809,7 @@ mod zksync {
     };
 
     #[allow(dead_code)]
-    pub type BaseLayerCircuit =
-        ZkSyncBaseLayerCircuit<F, VmWitnessOracle<F>, ZkSyncDefaultRoundFunction>;
+    pub type BaseLayerCircuit = ZkSyncBaseLayerCircuit;
 
     fn scan_directory<P: AsRef<Path>>(dir: P) -> Vec<PathBuf> {
         let mut file_paths = vec![];


### PR DESCRIPTION
# What ❔

* Updated circuit_definitions dependency

## Why ❔

* This new version doesn't export generics anymore, and should compile faster.
