### PR TITLE
fix L2 persistence bug on unsupported device 

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -84,11 +84,13 @@ impl ProverContext {
                 aux_events,
                 aux_h2d_buffer,
             });
-            // 10 sets of powers * 2X safety margin
-            set_l2_persistence_carveout(2 * 10 * 8 * (1 << 12))?;
-            set_l2_persistence_for_twiddles(get_stream())?;
-            for stream in _aux_streams() {
-                set_l2_persistence_for_twiddles(stream)?;
+            if l2_persist_max != 0 {
+                // 10 sets of powers * 2X safety margin
+                set_l2_persistence_carveout(2 * 10 * 8 * (1 << 12))?;
+                set_l2_persistence_for_twiddles(get_stream())?;
+                for stream in _aux_streams() {
+                    set_l2_persistence_for_twiddles(stream)?;
+                }
             }
         };
         Ok(Self {})


### PR DESCRIPTION
# What ❔

This PR fixes a bug that surfaces on devices that do not support L2 persistence.

## Why ❔

It's a bug.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).

