### PR TITLE
improve device allocator memory allocation logic

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -121,7 +121,7 @@ impl ProverContext {
         let cuda_ctx = CudaContext::create(12, 12)?;
         // grab small slice then consume everything
         let small_device_alloc = SmallStaticDeviceAllocator::init()?;
-        let device_alloc = StaticDeviceAllocator::init(num_blocks, block_size)?;
+        let device_alloc = StaticDeviceAllocator::init(num_blocks, num_blocks, block_size)?;
         let small_host_alloc = SmallStaticHostAllocator::init()?;
         let host_alloc = StaticHostAllocator::init(1 << 8, block_size)?;
         Self::create_internal(


### PR DESCRIPTION
# What ❔

This PR implements a better memory allocation logic to avoid allocation failures in cases where not the whole memory that is reported as free can be actually allocated.

## Why ❔

Attempting to allocate close to all free memory can fail if for example the memory is fragmented.

## Checklist

- [x] PR title corresponds to the body of PR (we generate changelog entries from PRs).
- [x] Code has been formatted via `cargo fmt` and linted via `cargo check`.
